### PR TITLE
fix: Admin-Session-Cookie mit Secure-Flag (#72)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,3 +21,6 @@ QR_CITY=...
 # Admin (bcrypt-Hashes, Format: label:hash,label:hash)
 # Hash generieren: python -c "import bcrypt; print(bcrypt.hashpw(b'mein-passwort', bcrypt.gensalt()).decode())"
 ADMIN_CREDENTIALS=owner:$2b$12$...,dev:$2b$12$...
+
+# Cookie-Sicherheit: in Produktion (HTTPS) IMMER True. Lokal/Dev auf False, falls ohne TLS getestet wird.
+COOKIE_SECURE=True

--- a/app/config.py
+++ b/app/config.py
@@ -23,6 +23,7 @@ class Settings(BaseSettings):
 
     admin_credentials: str = ""  # "label:bcrypt_hash,label:bcrypt_hash"
     admin_session_max_age: int = 86400  # 24h
+    cookie_secure: bool = True  # in dev via .env auf False setzen
 
     app_version: str = "dev"
 

--- a/app/routers/admin.py
+++ b/app/routers/admin.py
@@ -107,6 +107,7 @@ def admin_login(
         token,
         httponly=True,
         samesite="strict",
+        secure=settings.cookie_secure,
         max_age=settings.admin_session_max_age,
     )
     return response

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,6 +34,7 @@ def db(tmp_path):
 def client(tmp_path, monkeypatch):
     db_path = str(tmp_path / "test.db")
     monkeypatch.setattr("app.config.settings.database_path", db_path)
+    monkeypatch.setattr("app.config.settings.cookie_secure", False)
     monkeypatch.setattr(
         "app.routers.bestellungen.sende_bestellbestaetigung", lambda **kw: None
     )
@@ -57,6 +58,7 @@ def admin_client(tmp_path, monkeypatch):
     pw_hash = bcrypt.hashpw(b"testpass", bcrypt.gensalt()).decode()
     monkeypatch.setattr("app.config.settings.database_path", str(tmp_path / "test.db"))
     monkeypatch.setattr("app.config.settings.admin_credentials", f"dev:{pw_hash}")
+    monkeypatch.setattr("app.config.settings.cookie_secure", False)
     from app.database import init_db
 
     init_db()

--- a/tests/test_api_admin.py
+++ b/tests/test_api_admin.py
@@ -18,6 +18,19 @@ class TestAdminLogin:
         assert resp.headers["location"] == "/admin/"
         assert "admin_session" in resp.cookies
 
+    def test_login_cookie_secure_flag(self, admin_client, csrf_token, monkeypatch):
+        monkeypatch.setattr("app.config.settings.cookie_secure", True)
+        resp = admin_client.post(
+            "/admin/login",
+            data={"password": "testpass", "csrf_token": csrf_token},
+            follow_redirects=False,
+        )
+        set_cookie = resp.headers.get("set-cookie", "")
+        assert "admin_session=" in set_cookie
+        assert "Secure" in set_cookie
+        assert "HttpOnly" in set_cookie
+        assert "SameSite=strict" in set_cookie.lower() or "samesite=strict" in set_cookie.lower()
+
     def test_login_wrong_password(self, admin_client, csrf_token):
         resp = admin_client.post(
             "/admin/login",

--- a/tests/test_api_rabattcodes.py
+++ b/tests/test_api_rabattcodes.py
@@ -114,6 +114,7 @@ def _make_admin_client(tmp_path, monkeypatch):
     pw_hash = bcrypt.hashpw(b"testpass", bcrypt.gensalt()).decode()
     monkeypatch.setattr("app.config.settings.database_path", str(tmp_path / "admin_test.db"))
     monkeypatch.setattr("app.config.settings.admin_credentials", f"dev:{pw_hash}")
+    monkeypatch.setattr("app.config.settings.cookie_secure", False)
     from app.database import init_db
 
     init_db()

--- a/tests/test_e2e_bestellzyklus.py
+++ b/tests/test_e2e_bestellzyklus.py
@@ -18,6 +18,7 @@ def e2e_client(tmp_path, monkeypatch):
     pw_hash = _make_hash("testpass")
     monkeypatch.setattr("app.config.settings.database_path", str(tmp_path / "test.db"))
     monkeypatch.setattr("app.config.settings.admin_credentials", f"dev:{pw_hash}")
+    monkeypatch.setattr("app.config.settings.cookie_secure", False)
     from app.database import init_db
 
     init_db()


### PR DESCRIPTION
## Summary
- `admin_session`-Cookie wird mit `Secure`-Flag gesetzt — keine Übertragung über HTTP mehr
- Toggle via `settings.cookie_secure` (Default `True`), in Test-Fixtures `False`
- Neuer Test prüft `Set-Cookie`-Header auf `Secure`/`HttpOnly`/`SameSite=strict`

Closes #72

## Test plan
- [x] `make test` (147 passed)
- [ ] Nach Deploy: Browser-DevTools → Cookie `admin_session` zeigt `Secure ✓`