### PR TITLE
fix: CI — cookie_secure in Tests deaktivieren

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,12 @@ from app.services.rate_limit import bestellung_limiter, login_limiter
 
 
 @pytest.fixture(autouse=True)
+def _disable_cookie_secure(monkeypatch):
+    """Tests laufen über http://testserver — Secure-Cookies würden sonst verworfen."""
+    monkeypatch.setattr("app.config.settings.cookie_secure", False)
+
+
+@pytest.fixture(autouse=True)
 def _reset_rate_limit_state():
     login_limiter.reset()
     bestellung_limiter.reset()


### PR DESCRIPTION
Behebt CI-Failure nach #85: httpx verwirft Secure-Cookies über http://testserver, wodurch die Identity-gebundene CSRF-Validierung 403 statt erwarteter Codes liefert. Autouse-Fixture setzt cookie_secure=False für alle Tests.