### PR TITLE
fix: Mixed-Content auf Produktion beheben (uvicorn --proxy-headers)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,4 +25,7 @@ ARG APP_VERSION=dev
 ENV APP_VERSION=${APP_VERSION}
 
 # DB-Migration beim Container-Start (nicht Build), damit sie auf das persistente Volume schreibt
-CMD ["sh", "-c", "python -c 'from app.database import init_db; init_db()' && uvicorn app.main:app --host 0.0.0.0 --port 8000"]
+# --proxy-headers / --forwarded-allow-ips='*': hinter Fly-Proxy nötig, damit uvicorn
+# X-Forwarded-Proto auswertet. Sonst baut Starlettes url_for()/307-Redirects absolute
+# http://-URLs → Mixed Content blockt CSS, /admin redirected auf http.
+CMD ["sh", "-c", "python -c 'from app.database import init_db; init_db()' && uvicorn app.main:app --host 0.0.0.0 --port 8000 --proxy-headers --forwarded-allow-ips=*"]


### PR DESCRIPTION
## Summary
- Homepage und /admin waren auf olivalle.ch kaputt: CSS wurde als Mixed Content blockiert (\`<link href=\"http://olivalle.ch/static/css/app.css\">\` auf einer https-Seite), /admin redirected 307 auf http.
- Ursache: uvicorn lief hinter dem Fly-Proxy ohne \`--proxy-headers\` / \`--forwarded-allow-ips=*\`. Default ist nur \`127.0.0.1\`, Fly kommt aus anderem Netz → \`X-Forwarded-Proto\` wurde ignoriert → Starlette hielt alles für http → \`url_for\` und Trailing-Slash-Redirects erzeugten absolute http-URLs.
- Fix: Flags im Dockerfile-CMD ergänzt. Ein-Zeilen-Change.

Die bestehende \`redirect_www\`/\`security_headers\`-Middleware liest \`x-forwarded-proto\` manuell und war deshalb nicht betroffen — aber \`url_for\` und Starlette-interne Redirects nicht.

Nicht in diesem PR (Folge-Issue): Die CSP blockt Inline-\`onclick\`-Handler (\"In den Warenkorb\"-Buttons). Plan liegt bereits unter \`docs/superpowers/plans/2026-04-08-csp-nonce-inline-scripts.md\`.

## Test plan
- [ ] Nach Deploy: \`curl -s https://olivalle.ch/ | grep stylesheet\` zeigt \`https://\` (nicht \`http://\`)
- [ ] \`curl -sI https://olivalle.ch/admin\` → 307 Location mit \`https://\`
- [ ] Homepage im Browser: Styling da, Produktkarten sichtbar
- [ ] /admin im Browser: Login-Seite gestylt

🤖 Generated with [Claude Code](https://claude.com/claude-code)