### PR TITLE
chore: version bump auf 1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "olivalle"
-version = "0.1"
+version = "1.0"
 requires-python = ">=3.13"
 dependencies = [
     "fastapi>=0.115",


### PR DESCRIPTION
Symbolischer Version-Bump von 0.1 auf 1.0 nach erfolgreichem Go-Live (Mixed-Content-Fix #91 + CSP-Inline-Handler-Fix #92 in Produktion).