### PR TITLE
fix: Stripe-Checkout crasht durch nicht aktivierte TWINT-Methode (#97)

### DIFF
--- a/app/services/stripe_service.py
+++ b/app/services/stripe_service.py
@@ -43,7 +43,6 @@ def erstelle_checkout_session(
         discounts = [{"coupon": coupon.id}]
 
     session_params = {
-        "payment_method_types": ["card", "twint"],
         "line_items": line_items,
         "mode": "payment",
         "success_url": f"{settings.base_url}/bestaetigung?session_id={{CHECKOUT_SESSION_ID}}",


### PR DESCRIPTION
## Summary
- Entfernt `payment_method_types=["card", "twint"]` aus `erstelle_checkout_session`
- Stripe nutzt jetzt automatisch die im Dashboard aktivierten Methoden (aktuell: Karte)
- Fixt den 500er, den SH beim Checkout gemeldet hat

## Root Cause
TWINT wurde im Stripe-Account abgelehnt (siehe #68), war aber im Code hart verdrahtet. `stripe.checkout.Session.create` warf deshalb bei jedem Stripe-Checkout eine `InvalidRequestError`. Die Bestellung wurde vorher angelegt und committed — darum taucht sie im Admin-Dashboard auf, der Kunde sieht aber "Internal Server Error".

## Zusammenhang
- Closes #97
- Sobald #68 (TWINT-Freigabe durch Stripe) durch ist, greift TWINT automatisch ohne weitere Code-Änderung.

## Test plan
- [ ] Lokal: Checkout mit Zahlungsart Stripe durchklicken, Redirect auf Stripe-Checkout statt 500
- [ ] Nach Deploy: SH testet echten Stripe-Checkout auf olivalle.ch
- [ ] Admin-Dashboard: Bestellung erscheint mit korrektem Status

🤖 Generated with [Claude Code](https://claude.com/claude-code)
