### PR TITLE
fix: Admin-Dashboard zeigt Zeiten in Europe/Zurich (#96)

### DIFF
--- a/app/repositories/admin_repo.py
+++ b/app/repositories/admin_repo.py
@@ -1,4 +1,20 @@
 import sqlite3
+from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
+
+ZURICH_TZ = ZoneInfo("Europe/Zurich")
+_UTC = ZoneInfo("UTC")
+
+
+def _to_utc_str(dt: datetime) -> str:
+    """TZ-aware datetime → SQLite-kompatibles UTC-String-Format."""
+    return dt.astimezone(_UTC).strftime("%Y-%m-%d %H:%M:%S")
+
+
+def _next_month_start(dt: datetime) -> datetime:
+    if dt.month == 12:
+        return dt.replace(year=dt.year + 1, month=1)
+    return dt.replace(month=dt.month + 1)
 
 
 def log_eintrag_schreiben(
@@ -19,6 +35,15 @@ def log_eintrag_schreiben(
 
 
 def get_dashboard_stats(conn: sqlite3.Connection) -> dict:
+    # erstellt_am wird als UTC gespeichert (SQLite datetime('now')).
+    # Für "heute" und "aktueller Monat" in Europe/Zurich rechnen wir
+    # die lokalen Grenzen in Python aus und vergleichen als UTC-Strings.
+    now_zh = datetime.now(tz=ZURICH_TZ)
+    today_start_zh = now_zh.replace(hour=0, minute=0, second=0, microsecond=0)
+    tomorrow_start_zh = today_start_zh + timedelta(days=1)
+    month_start_zh = today_start_zh.replace(day=1)
+    next_month_start_zh = _next_month_start(month_start_zh)
+
     offene = conn.execute(
         "SELECT COUNT(*) as c FROM bestellungen WHERE status IN ('neu', 'bezahlt')"
     ).fetchone()["c"]
@@ -26,11 +51,14 @@ def get_dashboard_stats(conn: sqlite3.Connection) -> dict:
     umsatz = conn.execute(
         "SELECT COALESCE(SUM(total_chf), 0) as s FROM bestellungen "
         "WHERE status != 'storniert' "
-        "AND strftime('%Y-%m', erstellt_am) = strftime('%Y-%m', 'now')"
+        "AND erstellt_am >= ? AND erstellt_am < ?",
+        (_to_utc_str(month_start_zh), _to_utc_str(next_month_start_zh)),
     ).fetchone()["s"]
 
     heute = conn.execute(
-        "SELECT COUNT(*) as c FROM bestellungen WHERE date(erstellt_am) = date('now')"
+        "SELECT COUNT(*) as c FROM bestellungen "
+        "WHERE erstellt_am >= ? AND erstellt_am < ?",
+        (_to_utc_str(today_start_zh), _to_utc_str(tomorrow_start_zh)),
     ).fetchone()["c"]
 
     return {
@@ -66,11 +94,17 @@ def get_bestellungen_liste(
         )
         params.extend([f"%{suche}%", f"%{suche}%", suche])
     if datum_von:
-        query += " AND date(b.erstellt_am) >= ?"
-        params.append(datum_von)
+        # Zurich-Datum → UTC-Startzeitpunkt
+        dv = datetime.strptime(datum_von, "%Y-%m-%d").replace(tzinfo=ZURICH_TZ)
+        query += " AND b.erstellt_am >= ?"
+        params.append(_to_utc_str(dv))
     if datum_bis:
-        query += " AND date(b.erstellt_am) <= ?"
-        params.append(datum_bis)
+        # Zurich-Datum (inklusiv) → UTC-Startzeitpunkt des Folgetages
+        db_end = datetime.strptime(datum_bis, "%Y-%m-%d").replace(
+            tzinfo=ZURICH_TZ
+        ) + timedelta(days=1)
+        query += " AND b.erstellt_am < ?"
+        params.append(_to_utc_str(db_end))
 
     query += " ORDER BY b.erstellt_am DESC, b.id DESC"
 

--- a/app/templating.py
+++ b/app/templating.py
@@ -1,11 +1,31 @@
 import json
+from datetime import datetime
 from pathlib import Path
+from zoneinfo import ZoneInfo
 
 from fastapi.templating import Jinja2Templates
 from starlette.requests import Request
 
 from app.config import settings
 from app.labels import zahlungsart_admin
+
+_ZURICH_TZ = ZoneInfo("Europe/Zurich")
+_UTC = ZoneInfo("UTC")
+
+
+def zurich_time(value: str | None) -> str:
+    """Konvertiert einen UTC-Timestamp-String (SQLite-Format) nach Europe/Zurich.
+
+    Format der Ausgabe: ``YYYY-MM-DD HH:MM`` in Schweizer Lokalzeit.
+    """
+    if not value:
+        return ""
+    try:
+        dt = datetime.strptime(value[:19], "%Y-%m-%d %H:%M:%S")
+    except ValueError:
+        return value
+    dt_utc = dt.replace(tzinfo=_UTC)
+    return dt_utc.astimezone(_ZURICH_TZ).strftime("%Y-%m-%d %H:%M")
 
 
 def csp_nonce_processor(request: Request) -> dict:
@@ -23,3 +43,4 @@ templates.env.globals["app_version"] = settings.app_version
 templates.env.globals["active_page"] = ""
 templates.env.filters["from_json"] = json.loads
 templates.env.filters["zahlungsart_admin"] = zahlungsart_admin
+templates.env.filters["zurich_time"] = zurich_time

--- a/templates/admin/bestellung_detail.html
+++ b/templates/admin/bestellung_detail.html
@@ -137,7 +137,7 @@
                 </tfoot>
             </table>
             <div class="mt-3 text-sm text-stone-400">
-                Zahlungsart: {{ bestellung.zahlungsart | zahlungsart_admin }} · Erstellt: {{ bestellung.erstellt_am[:16] }}
+                Zahlungsart: {{ bestellung.zahlungsart | zahlungsart_admin }} · Erstellt: {{ bestellung.erstellt_am | zurich_time }}
             </div>
             {% if bestellung.kommentar %}
             <div class="mt-4 p-3 rounded bg-amber-900/30 border border-amber-700/50">
@@ -181,7 +181,7 @@
                 {% for log in logs %}
                 <div class="border-l-2 {% if log.aktion == 'status_geaendert' %}border-accent{% elif log.aktion == 'email_ausgang' %}border-blue-400{% elif log.aktion == 'notiz_hinzugefuegt' %}border-stone-500{% else %}border-stone-600{% endif %} pl-4 py-2">
                     <div class="flex items-center gap-2 text-xs text-stone-400">
-                        <span>{{ log.zeitpunkt[:16] }}</span>
+                        <span>{{ log.zeitpunkt | zurich_time }}</span>
                         <span class="bg-stone-600 rounded px-1.5 py-0.5">{{ log.admin_label }}</span>
                         <span>{{ log.aktion }}</span>
                     </div>

--- a/templates/admin/dashboard.html
+++ b/templates/admin/dashboard.html
@@ -72,7 +72,7 @@
             <tr class="bestellung-row border-b border-stone-600/50 hover:bg-stone-600 cursor-pointer transition-colors"
                 data-href="/admin/bestellungen/{{ b.id }}">
                 <td class="px-4 py-3 font-mono">#{{ b.id }}</td>
-                <td class="px-4 py-3">{{ b.erstellt_am[:16] }}</td>
+                <td class="px-4 py-3">{{ b.erstellt_am | zurich_time }}</td>
                 <td class="px-4 py-3">{{ b.vorname }} {{ b.nachname }}</td>
                 <td class="px-4 py-3">
                     {% if b.status in ['neu'] %}


### PR DESCRIPTION
## Summary
- Closes #96
- SQLite speichert Timestamps als UTC; Admin zeigte sie roh und rechnete "Heute" gegen UTC — falsch rund um Mitternacht Zurich
- Neuer Jinja-Filter \`zurich_time\` fürs Display, Dashboard-Stats und Datumsfilter rechnen Grenzen in Europe/Zurich

## Änderungen
- [app/templating.py](app/templating.py): neuer \`zurich_time\`-Filter
- [app/repositories/admin_repo.py](app/repositories/admin_repo.py): \`get_dashboard_stats\` und Listen-Datumsfilter TZ-aware
- [templates/admin/dashboard.html](templates/admin/dashboard.html), [templates/admin/bestellung_detail.html](templates/admin/bestellung_detail.html): \`| zurich_time\` statt \`[:16]\`

## Test plan
- [x] \`uv run pytest\` — 176 passed
- [ ] Manuell auf Live: Admin-Dashboard zeigt aktuelle Zeit in CEST
- [ ] Manuell: "Bestellungen heute" und "Umsatz Monat" korrekt rund um Mitternacht

🤖 Generated with [Claude Code](https://claude.com/claude-code)