### PR TITLE
Ruff-Backlog Cleanup + CI-Drift-Schutz (#103)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,22 @@
+name: Lint
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  ruff:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.13"
+      - name: Install dev dependencies
+        run: uv sync --extra dev
+      - name: Ruff Check
+        run: uv run ruff check app tests
+      - name: Ruff Format Check
+        run: uv run ruff format --check app tests

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   ruff:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v5

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .DEFAULT_GOAL := help
 
-.PHONY: help dev test lint format migrate docs css-build css-watch
+.PHONY: help dev test lint lint-all format migrate docs css-build css-watch
 
 help: ## Alle verfügbaren Befehle anzeigen
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-15s\033[0m %s\n", $$1, $$2}'
@@ -22,6 +22,10 @@ lint: ## Linting (Ruff)
 
 format: ## Code formatieren (Ruff)
 	uv run ruff format .
+
+lint-all: ## Ruff-Check + Format-Check (gleich wie CI)
+	uv run ruff check app tests
+	uv run ruff format --check app tests
 
 migrate: ## Datenbank-Migration ausführen
 	uv run python -c "from app.database import init_db; init_db()"

--- a/app/repositories/rabattcode_repo.py
+++ b/app/repositories/rabattcode_repo.py
@@ -38,9 +38,7 @@ def rabattcode_anlegen(
 
 def rabattcode_laden(conn: sqlite3.Connection, code_id: int) -> dict | None:
     """Rabattcode anhand der ID laden."""
-    row = conn.execute(
-        "SELECT * FROM rabattcodes WHERE id = ?", (code_id,)
-    ).fetchone()
+    row = conn.execute("SELECT * FROM rabattcodes WHERE id = ?", (code_id,)).fetchone()
     return dict(row) if row else None
 
 
@@ -60,9 +58,7 @@ def alle_rabattcodes(conn: sqlite3.Connection) -> list[dict]:
     return [dict(r) for r in rows]
 
 
-def rabattcode_aktualisieren(
-    conn: sqlite3.Connection, code_id: int, **felder
-) -> None:
+def rabattcode_aktualisieren(conn: sqlite3.Connection, code_id: int, **felder) -> None:
     """Rabattcode-Felder aktualisieren."""
     if not felder:
         return

--- a/app/routers/admin.py
+++ b/app/routers/admin.py
@@ -76,9 +76,7 @@ def admin_login_page(
 ):
     if not csrf_id:
         csrf_id = secrets.token_hex(16)
-    csrf_token = generiere_csrf_token(
-        settings.secret_key, identity=f"anon:{csrf_id}"
-    )
+    csrf_token = generiere_csrf_token(settings.secret_key, identity=f"anon:{csrf_id}")
     response = templates.TemplateResponse(
         request, "admin/login.html", {"csrf_token": csrf_token}
     )

--- a/app/routers/rabattcodes.py
+++ b/app/routers/rabattcodes.py
@@ -1,4 +1,3 @@
-
 from fastapi import APIRouter, Cookie, Form, Request
 from fastapi.responses import RedirectResponse
 from pydantic import BaseModel
@@ -58,9 +57,7 @@ def rabattcode_pruefen(req: RabattcodeRequest):
 
 
 @router.get("/admin/rabattcodes")
-def admin_rabattcodes_liste(
-    request: Request, admin_session: str | None = Cookie(None)
-):
+def admin_rabattcodes_liste(request: Request, admin_session: str | None = Cookie(None)):
     label = _get_admin_label(admin_session)
     if not label:
         return RedirectResponse("/admin/login", status_code=303)
@@ -83,9 +80,7 @@ def admin_rabattcodes_liste(
 
 
 @router.get("/admin/rabattcodes/neu")
-def admin_rabattcode_neu(
-    request: Request, admin_session: str | None = Cookie(None)
-):
+def admin_rabattcode_neu(request: Request, admin_session: str | None = Cookie(None)):
     label = _get_admin_label(admin_session)
     if not label:
         return RedirectResponse("/admin/login", status_code=303)
@@ -130,9 +125,7 @@ def admin_rabattcode_erstellen(
             mindestbestellwert_chf=float(mindestbestellwert_chf)
             if mindestbestellwert_chf
             else None,
-            max_einloesungen=int(max_einloesungen)
-            if max_einloesungen
-            else None,
+            max_einloesungen=int(max_einloesungen) if max_einloesungen else None,
         )
         log_eintrag_schreiben(
             conn,
@@ -202,9 +195,7 @@ def admin_rabattcode_speichern(
             mindestbestellwert_chf=float(mindestbestellwert_chf)
             if mindestbestellwert_chf
             else None,
-            max_einloesungen=int(max_einloesungen)
-            if max_einloesungen
-            else None,
+            max_einloesungen=int(max_einloesungen) if max_einloesungen else None,
             aktiv=1 if aktiv == "1" else 0,
         )
     finally:

--- a/app/routers/webhooks.py
+++ b/app/routers/webhooks.py
@@ -1,4 +1,3 @@
-
 import stripe
 from fastapi import APIRouter, HTTPException, Request
 
@@ -72,6 +71,7 @@ async def stripe_webhook(request: Request):
                         rabattcode_name = rc_row["code"]
 
                 from app.services.email_service import sende_bestellbestaetigung
+
                 sende_bestellbestaetigung(
                     empfaenger=best["email"],
                     bestell_id=best["id"],
@@ -86,6 +86,7 @@ async def stripe_webhook(request: Request):
                 from app.services.email_service import (
                     sende_stakeholder_benachrichtigung,
                 )
+
                 sende_stakeholder_benachrichtigung(
                     bestell_id=best["id"],
                     kunde={
@@ -139,7 +140,9 @@ async def stripe_webhook(request: Request):
                     conn,
                     admin_label="system",
                     aktion="status_geaendert",
-                    details=json.dumps({"von": "neu", "nach": "storniert", "grund": grund}),
+                    details=json.dumps(
+                        {"von": "neu", "nach": "storniert", "grund": grund}
+                    ),
                     bestellung_id=bestell_id,
                 )
         finally:

--- a/app/services/bestell_service.py
+++ b/app/services/bestell_service.py
@@ -3,9 +3,7 @@ import sqlite3
 from app.models import WarenkorbItem
 
 
-def berechne_versandkosten(
-    warenwert: float, versandart: str = "versand"
-) -> float:
+def berechne_versandkosten(warenwert: float, versandart: str = "versand") -> float:
     if versandart == "abholung":
         return 0.0
     return 0.0 if warenwert >= 100 else 9.90

--- a/app/services/email_service.py
+++ b/app/services/email_service.py
@@ -152,8 +152,6 @@ def sende_status_email(
         )
 
 
-
-
 def sende_stakeholder_benachrichtigung(
     bestell_id: int,
     kunde: dict,

--- a/app/services/rabattcode_service.py
+++ b/app/services/rabattcode_service.py
@@ -54,7 +54,10 @@ def pruefe_rabattcode(
     ):
         return {
             "gueltig": False,
-            "fehler": f"Mindestbestellwert CHF {rc['mindestbestellwert_chf']:.2f} nicht erreicht.",
+            "fehler": (
+                f"Mindestbestellwert CHF {rc['mindestbestellwert_chf']:.2f} "
+                "nicht erreicht."
+            ),
         }
 
     rabattbetrag = berechne_rabatt(rc["rabattart"], rc["rabattwert"], subtotal)

--- a/app/services/stripe_service.py
+++ b/app/services/stripe_service.py
@@ -49,7 +49,9 @@ def erstelle_checkout_session(
     session_params = {
         "line_items": line_items,
         "mode": "payment",
-        "success_url": f"{settings.base_url}/bestaetigung?session_id={{CHECKOUT_SESSION_ID}}",
+        "success_url": (
+            f"{settings.base_url}/bestaetigung?session_id={{CHECKOUT_SESSION_ID}}"
+        ),
         "cancel_url": f"{settings.base_url}/checkout",
         "metadata": {"bestell_id": str(bestell_id)},
     }

--- a/app/services/stripe_service.py
+++ b/app/services/stripe_service.py
@@ -13,24 +13,28 @@ def erstelle_checkout_session(
 ) -> stripe.checkout.Session:
     line_items = []
     for pos in positionen:
-        line_items.append({
-            "price_data": {
-                "currency": "chf",
-                "product_data": {"name": pos["name"]},
-                "unit_amount": int(pos["einzelpreis_chf"] * 100),
-            },
-            "quantity": pos["menge"],
-        })
+        line_items.append(
+            {
+                "price_data": {
+                    "currency": "chf",
+                    "product_data": {"name": pos["name"]},
+                    "unit_amount": int(pos["einzelpreis_chf"] * 100),
+                },
+                "quantity": pos["menge"],
+            }
+        )
 
     if versandkosten > 0:
-        line_items.append({
-            "price_data": {
-                "currency": "chf",
-                "product_data": {"name": "Versandkosten"},
-                "unit_amount": int(versandkosten * 100),
-            },
-            "quantity": 1,
-        })
+        line_items.append(
+            {
+                "price_data": {
+                    "currency": "chf",
+                    "product_data": {"name": "Versandkosten"},
+                    "unit_amount": int(versandkosten * 100),
+                },
+                "quantity": 1,
+            }
+        )
 
     discounts = []
     if rabattbetrag > 0:

--- a/docs/superpowers/plans/2026-04-21-issue-103-ruff-backlog.md
+++ b/docs/superpowers/plans/2026-04-21-issue-103-ruff-backlog.md
@@ -1,0 +1,652 @@
+# Ruff-Backlog Cleanup + Drift-Schutz Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Alle 45 Ruff-Lint-Violations und 13 Format-Drifts in einem Big-Bang-PR beheben und einen CI-Workflow einziehen, der künftigen Drift auf PRs blockiert.
+
+**Architecture:** Ein Feature-Branch, 5 semantisch getrennte Commits (1× `ruff format`, 3× manuelle Lint-Fixes gruppiert nach Bereich, 1× CI-Workflow + Makefile-Target). Ein einziger PR gegen `main`. Keine funktionalen Änderungen — die 207 bestehenden Tests bleiben unverändert grün und sind der einzige Regressions-Test.
+
+**Tech Stack:** Ruff 0.9+ (linter + formatter), Python 3.13, uv (package manager), GitHub Actions, Make.
+
+**Spec:** `docs/superpowers/specs/2026-04-21-ruff-backlog-design.md`
+**Issue:** [#103](https://github.com/konstantinniedermann/olivalle-webshop/issues/103)
+
+**Anmerkung zur Commit-Anzahl:** Die Spec skizzierte 3 Commits. Der Plan feingranuliert auf 5 Commits für atomare Rollbacks pro Bereich. Die drei mittleren `fix:`-Commits können vor Merge optional zu einem einzigen gesquasht werden.
+
+---
+
+## File Structure
+
+Welche Dateien angefasst werden und wofür:
+
+| Datei | Zweck | Tasks |
+|---|---|---|
+| `app/routers/webhooks.py` | 1× E501-Fix (Z.142) | Task 3 |
+| `app/services/stripe_service.py` | 1× E501-Fix (Z.48) | Task 3 |
+| `app/services/rabattcode_service.py` | 1× E501-Fix (Z.57) | Task 3 |
+| `tests/test_rabattcode_service.py` | Imports nach oben + E501-Fixes | Task 4 |
+| `tests/test_api_admin.py` + 8 weitere Test-Files | E501-Fixes | Task 5 |
+| `.github/workflows/lint.yml` | Neue CI-Datei | Task 6 |
+| `Makefile` | Neues Target `lint-all` | Task 6 |
+| 13 Files in `app/` + `tests/` | Layout durch `ruff format` | Task 2 |
+
+---
+
+## Task 1: Feature-Branch anlegen
+
+**Files:** keine
+
+- [ ] **Step 1: Vom aktuellen main-Stand branchen**
+
+```bash
+git status
+```
+Expected: `working tree clean, your branch is up to date with 'origin/main'`
+
+- [ ] **Step 2: Branch erstellen**
+
+```bash
+git checkout -b ruff-backlog-103
+```
+Expected: `Switched to a new branch 'ruff-backlog-103'`
+
+- [ ] **Step 3: Baseline-Verifikation — Tests grün vor Start**
+
+```bash
+uv run pytest -q
+```
+Expected: `207 passed`
+
+- [ ] **Step 4: Baseline dokumentieren — Ruff zeigt 45 + 13**
+
+```bash
+uv run ruff check app tests 2>&1 | tail -2
+uv run ruff format --check app tests 2>&1 | tail -2
+```
+Expected:
+- `Found 45 errors.`
+- `13 files would be reformatted, 49 files already formatted`
+
+---
+
+## Task 2: Commit 1 — `ruff format` über `app/` und `tests/`
+
+**Files:** 13 Dateien werden automatisch umformatiert:
+- Modify: `app/repositories/rabattcode_repo.py`
+- Modify: `app/routers/admin.py`
+- Modify: `app/routers/rabattcodes.py`
+- Modify: `app/routers/webhooks.py`
+- Modify: `app/services/bestell_service.py`
+- Modify: `app/services/email_service.py`
+- Modify: `app/services/stripe_service.py`
+- Modify: `tests/test_api_admin.py`
+- Modify: `tests/test_api_rabattcodes.py`
+- Modify: `tests/test_api_webhooks.py`
+- Modify: `tests/test_csrf.py`
+- Modify: `tests/test_email_service.py`
+- Modify: `tests/test_rabattcode_service.py`
+
+- [ ] **Step 1: Format-Check — zeigt welche Files drift haben**
+
+```bash
+uv run ruff format --check app tests
+```
+Expected: `13 files would be reformatted, 49 files already formatted`
+
+- [ ] **Step 2: Auto-Format anwenden**
+
+```bash
+uv run ruff format app tests
+```
+Expected: `13 files reformatted, 49 files left unchanged`
+
+- [ ] **Step 3: Format-Check nach Anwendung — muss clean sein**
+
+```bash
+uv run ruff format --check app tests
+```
+Expected: `62 files already formatted` (exit 0)
+
+- [ ] **Step 4: Regressions-Test — alle Tests müssen grün bleiben**
+
+```bash
+uv run pytest -q
+```
+Expected: `207 passed`
+
+- [ ] **Step 5: Diff inspizieren — nur Layout-Änderungen?**
+
+```bash
+git diff --stat
+```
+Expected: Nur dict-/Funktionsaufruf-Layout-Änderungen in den 13 Files, keine Semantik.
+
+- [ ] **Step 6: Commit 1**
+
+```bash
+git add app/ tests/
+git commit -m "chore: ruff format über app/ und tests/
+
+Reine Layout-Angleichung der 13 Format-Drift-Files. Kein Semantik-Effekt,
+alle 207 Tests bleiben grün.
+
+Teil von #103."
+```
+
+---
+
+## Task 3: Commit 2a — E501-Fixes in `app/` (3 Stellen)
+
+**Files:**
+- Modify: `app/routers/webhooks.py:142`
+- Modify: `app/services/stripe_service.py:48`
+- Modify: `app/services/rabattcode_service.py:57`
+
+- [ ] **Step 1: Lint-Check auf `app/` — zeigt 3 E501**
+
+```bash
+uv run ruff check app --output-format=concise
+```
+Expected (3 Zeilen):
+```
+app/routers/webhooks.py:142:89: E501 Line too long (...)
+app/services/rabattcode_service.py:57:89: E501 Line too long (...)
+app/services/stripe_service.py:48:89: E501 Line too long (...)
+```
+
+Hinweis: Nach `ruff format` aus Task 2 können sich die Zeilennummern leicht verschoben haben. Arbeite mit den Zeilennummern, die `ruff check` jetzt meldet, nicht mit denen aus diesem Plan.
+
+- [ ] **Step 2: Fix `app/routers/webhooks.py` — Log-Detail-JSON**
+
+Aktuell (eine Zeile > 88 Zeichen):
+```python
+details=json.dumps({"von": "neu", "nach": "storniert", "grund": grund}),
+```
+
+Nachher (mehrzeilig):
+```python
+details=json.dumps(
+    {"von": "neu", "nach": "storniert", "grund": grund}
+),
+```
+
+Editiere die Datei entsprechend.
+
+- [ ] **Step 3: Fix `app/services/stripe_service.py` — success_url f-string**
+
+Aktuell:
+```python
+"success_url": f"{settings.base_url}/bestaetigung?session_id={{CHECKOUT_SESSION_ID}}",
+```
+
+Nachher:
+```python
+"success_url": (
+    f"{settings.base_url}/bestaetigung"
+    "?session_id={CHECKOUT_SESSION_ID}"
+),
+```
+
+Hinweis: `{{CHECKOUT_SESSION_ID}}` ist im f-string doppelt geklammert, um ein literales `{CHECKOUT_SESSION_ID}` auszugeben. Im nicht-f-string-Teil reicht einfach geklammert.
+
+- [ ] **Step 4: Fix `app/services/rabattcode_service.py` — Fehlermeldungs-f-string**
+
+Aktuell:
+```python
+"fehler": f"Mindestbestellwert CHF {rc['mindestbestellwert_chf']:.2f} nicht erreicht.",
+```
+
+Nachher:
+```python
+"fehler": (
+    f"Mindestbestellwert CHF {rc['mindestbestellwert_chf']:.2f} "
+    "nicht erreicht."
+),
+```
+
+- [ ] **Step 5: Lint-Check auf `app/` — muss clean sein**
+
+```bash
+uv run ruff check app
+```
+Expected: `All checks passed!`
+
+- [ ] **Step 6: Regressions-Test**
+
+```bash
+uv run pytest -q
+```
+Expected: `207 passed`
+
+- [ ] **Step 7: Stage aber NICHT committen (Commit folgt nach Task 5)**
+
+```bash
+git add app/routers/webhooks.py app/services/stripe_service.py app/services/rabattcode_service.py
+git status
+```
+Expected: Drei Files unter "Changes to be committed".
+
+---
+
+## Task 4: Commit 2b — E402 + E501 in `tests/test_rabattcode_service.py`
+
+**Files:**
+- Modify: `tests/test_rabattcode_service.py` (Imports-Reorg + E501-Fixes in SQL-Strings)
+
+Dieses File bekommt eine eigene Task weil es zwei verschiedene Fehlerarten kombiniert und die Import-Reorganisation strukturell wirkt.
+
+- [ ] **Step 1: Ist-Stand — Fehler in dieser Datei auflisten**
+
+```bash
+uv run ruff check tests/test_rabattcode_service.py --output-format=concise
+```
+Expected: 9× E501 + 2× E402 (genaue Zeilennummern können nach Task 2 leicht verschoben sein).
+
+- [ ] **Step 2: Imports an den Datei-Kopf verschieben**
+
+Das File beginnt mit einem leeren Kopf, dann Kapitel `# --- Migration Tests ---`, später `# --- Repository Tests ---` mit einem Import dazwischen, später `# --- Service Tests ---` mit einem weiteren Import.
+
+Nimm die zwei `from app.repositories.rabattcode_repo import (...)` und `from app.services.rabattcode_service import berechne_rabatt, pruefe_rabattcode` Zeilen und verschiebe sie an den Datei-Anfang (nach eventuellen stdlib-Imports oder Fixture-Imports, die dort schon stehen).
+
+Die `# --- Repository Tests ---` und `# --- Service Tests ---` Kommentare bleiben als Sektions-Marker stehen, aber ohne Imports direkt darunter.
+
+Die Import-Reihenfolge am File-Anfang soll sein:
+1. ggf. existierende stdlib-/third-party-Imports
+2. `from app.repositories.rabattcode_repo import (einloesung_speichern, ist_bereits_eingeloest, rabattcode_anlegen, rabattcode_laden, rabattcode_laden_by_code)`
+3. `from app.services.rabattcode_service import berechne_rabatt, pruefe_rabattcode`
+
+- [ ] **Step 3: E402-Verifikation**
+
+```bash
+uv run ruff check tests/test_rabattcode_service.py --select E402
+```
+Expected: `All checks passed!`
+
+- [ ] **Step 4: E501-Fixes in SQL-INSERT-Statements**
+
+Pattern: Die meisten E501 in diesem File sind SQL-INSERTs, bei denen zwar schon String-Concatenation verwendet wird, aber die einzelne Zeile noch zu lang ist.
+
+Beispiel (Z.29 im Original, verschiebt sich nach Task 2 ggf.):
+
+Aktuell:
+```python
+db.execute(
+    "INSERT INTO bestellungen (kunde_id, zahlungsart, versandart, versandkosten_chf, total_chf) "
+    "VALUES (1, 'stripe', 'versand', 9.90, 25.90)"
+)
+```
+
+Nachher (Spaltenliste auf zwei Zeilen):
+```python
+db.execute(
+    "INSERT INTO bestellungen "
+    "(kunde_id, zahlungsart, versandart, versandkosten_chf, total_chf) "
+    "VALUES (1, 'stripe', 'versand', 9.90, 25.90)"
+)
+```
+
+Weitere E501-Stellen in diesem File betreffen:
+- SELECT-Queries: gleiche Strategie (Zeile brechen, ggf. den WHERE-Teil in eigene String-Literal-Zeile).
+- SQL-INSERT mit noch längeren Spaltenlisten: Spaltenliste über mehrere Zeilen verteilen.
+
+Arbeite jede E501-Stelle so ab, dass jede resultierende Zeile ≤88 Zeichen ist. Nutze `ruff check tests/test_rabattcode_service.py` nach jedem Edit zum Gegencheck.
+
+- [ ] **Step 5: Lint-Check auf diese Datei — muss clean sein**
+
+```bash
+uv run ruff check tests/test_rabattcode_service.py
+```
+Expected: `All checks passed!`
+
+- [ ] **Step 6: Regressions-Test — nur diese Datei**
+
+```bash
+uv run pytest tests/test_rabattcode_service.py -q
+```
+Expected: Alle Tests aus diesem File grün.
+
+- [ ] **Step 7: Stage**
+
+```bash
+git add tests/test_rabattcode_service.py
+git status
+```
+
+---
+
+## Task 5: Commit 2c — E501-Fixes in den restlichen 8 Test-Files + Commit 2
+
+**Files:**
+- Modify: `tests/test_abholung_bar.py` (1× E501)
+- Modify: `tests/test_api_admin.py` (5× E501)
+- Modify: `tests/test_api_rabattcodes.py` (3× E501)
+- Modify: `tests/test_api_seiten.py` (2× E501)
+- Modify: `tests/test_api_webhooks.py` (1× E501)
+- Modify: `tests/test_e2e_bestellzyklus.py` (9× E501)
+- Modify: `tests/test_email_service.py` (11× E501)
+
+(Summen siehe Concise-Output aus Task 1.)
+
+- [ ] **Step 1: Liste aller Lint-Fehler in Tests ausdrucken als Checkliste**
+
+```bash
+uv run ruff check tests --output-format=concise
+```
+
+Arbeite die Liste von oben nach unten ab.
+
+- [ ] **Step 2: Fix-Pattern für SQL-Strings (E501 häufigster Fall)**
+
+Muster 1 — INSERT mit langer Spaltenliste:
+```python
+"INSERT INTO tabelle (spalte1, spalte2, spalte3, spalte4) "
+```
+→ Brechen an einem Komma:
+```python
+"INSERT INTO tabelle "
+"(spalte1, spalte2, spalte3, spalte4) "
+```
+
+Muster 2 — SELECT mit langem WHERE:
+```python
+row = db.execute("SELECT * FROM tabelle WHERE email = 'test@example.com'").fetchone()
+```
+→ Als mehrzeilig:
+```python
+row = db.execute(
+    "SELECT * FROM tabelle WHERE email = 'test@example.com'"
+).fetchone()
+```
+
+Muster 3 — Langer Docstring oder Kommentar:
+```python
+"""Sehr langer Docstring auf einer Zeile, der über 88 Zeichen hinausgeht und..."""
+```
+→ Mehrzeiliger Docstring:
+```python
+"""Sehr langer Docstring auf einer Zeile,
+der über 88 Zeichen hinausgeht und..."""
+```
+
+Muster 4 — HTML-Assertion-String:
+```python
+assert "<a href='/admin/bestellung/123' class='btn'>Details</a>" in resp.text
+```
+→ In Variable extrahieren oder String-Concatenation nutzen:
+```python
+erwartet = "<a href='/admin/bestellung/123' class='btn'>Details</a>"
+assert erwartet in resp.text
+```
+
+Wähle pro Stelle das Muster, das die natürliche Lesbarkeit am wenigsten stört.
+
+- [ ] **Step 3: File für File abarbeiten — `tests/test_abholung_bar.py`**
+
+```bash
+uv run ruff check tests/test_abholung_bar.py --output-format=concise
+```
+
+Fix anwenden, dann:
+```bash
+uv run ruff check tests/test_abholung_bar.py
+```
+Expected: `All checks passed!`
+
+- [ ] **Step 4: File für File — `tests/test_api_admin.py`**
+
+Gleiche Prozedur: `ruff check` → fix → `ruff check`.
+
+- [ ] **Step 5: File für File — `tests/test_api_rabattcodes.py`**
+
+- [ ] **Step 6: File für File — `tests/test_api_seiten.py`**
+
+- [ ] **Step 7: File für File — `tests/test_api_webhooks.py`**
+
+- [ ] **Step 8: File für File — `tests/test_e2e_bestellzyklus.py`**
+
+Grösstes File (9 Stellen). Empfehlung: `ruff check tests/test_e2e_bestellzyklus.py --output-format=concise` ausgeben lassen, dann jede Stelle einzeln editieren und am Ende verifizieren.
+
+- [ ] **Step 9: File für File — `tests/test_email_service.py`**
+
+Grösstes File nach `test_e2e_bestellzyklus.py` (11 Stellen). Die meisten davon sind SQL-INSERTs mit gleichem Schema — Muster 1 oben anwenden.
+
+- [ ] **Step 10: Gesamt-Lint-Check**
+
+```bash
+uv run ruff check app tests
+```
+Expected: `All checks passed!`
+
+- [ ] **Step 11: Gesamt-Format-Check (sicherstellen dass Edits nichts gebrochen haben)**
+
+```bash
+uv run ruff format --check app tests
+```
+Expected: exit 0.
+
+Falls nicht: `uv run ruff format app tests` erneut laufen lassen und dann `ruff check` nochmal gegenprüfen (Format kann manchmal Zeilen anders umbrechen als vom Entwickler erwartet).
+
+- [ ] **Step 12: Regressions-Test**
+
+```bash
+uv run pytest -q
+```
+Expected: `207 passed`
+
+- [ ] **Step 13: Commit 2 (alle Lint-Fixes zusammen)**
+
+```bash
+git add app/ tests/
+git commit -m "fix: Ruff-Lint-Violations (E501, E402) beheben
+
+- 3× E501 in app/ (webhooks, stripe_service, rabattcode_service)
+- 40× E501 in tests/ (mehrzeilige SQL-INSERTs und Docstrings)
+- 2× E402 in tests/test_rabattcode_service.py (Imports an Datei-Kopf)
+
+Keine funktionalen Änderungen. Alle 207 Tests grün.
+
+Teil von #103."
+```
+
+Hinweis: Tasks 3 und 4 hatten bereits `git add` gemacht. Dieser `git add app/ tests/` ist idempotent und staged nun auch die in Task 5 bearbeiteten Test-Files.
+
+---
+
+## Task 6: Commit 3 — CI-Workflow + Makefile-Target
+
+**Files:**
+- Create: `.github/workflows/lint.yml`
+- Modify: `Makefile` (neues Target `lint-all`, `.PHONY` erweitern)
+
+- [ ] **Step 1: CI-Workflow anlegen**
+
+Erstelle die Datei `.github/workflows/lint.yml` mit folgendem Inhalt:
+
+```yaml
+name: Lint
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  ruff:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.13"
+      - name: Install dev dependencies
+        run: uv sync --extra dev
+      - name: Ruff Check
+        run: uv run ruff check app tests
+      - name: Ruff Format Check
+        run: uv run ruff format --check app tests
+```
+
+- [ ] **Step 2: YAML-Validierung (offline, via Python)**
+
+```bash
+uv run python -c "import yaml; yaml.safe_load(open('.github/workflows/lint.yml'))"
+```
+Expected: exit 0, keine Ausgabe.
+
+- [ ] **Step 3: Makefile-Target `lint-all` hinzufügen**
+
+Aktueller Makefile-Kopf:
+```make
+.PHONY: help dev test lint format migrate docs css-build css-watch
+```
+
+Ändere zu:
+```make
+.PHONY: help dev test lint lint-all format migrate docs css-build css-watch
+```
+
+Füge nach dem bestehenden `format`-Target folgendes neues Target ein:
+
+```make
+lint-all: ## Ruff-Check + Format-Check (gleich wie CI)
+	uv run ruff check app tests
+	uv run ruff format --check app tests
+```
+
+Wichtig: Der Einrückungsbefehl unter dem Target muss ein **TAB** sein, kein Spaces (Make-Konvention).
+
+- [ ] **Step 4: `make help` testen — `lint-all` erscheint in der Liste**
+
+```bash
+make help
+```
+Expected: Zeile `lint-all       Ruff-Check + Format-Check (gleich wie CI)` erscheint.
+
+- [ ] **Step 5: `make lint-all` ausführen — muss grün sein**
+
+```bash
+make lint-all
+```
+Expected:
+- `All checks passed!`
+- exit 0 (keine Format-Diffs)
+
+- [ ] **Step 6: Commit 3**
+
+```bash
+git add .github/workflows/lint.yml Makefile
+git commit -m "feat: CI-Workflow für Ruff-Gate auf PRs
+
+- Neue .github/workflows/lint.yml: ruff check + format --check bei jedem PR
+- Neues Makefile-Target 'lint-all' für lokale Reproduktion des CI-Gates
+
+Schliesst #103."
+```
+
+---
+
+## Task 7: End-to-End Verifikation + PR
+
+**Files:** keine
+
+- [ ] **Step 1: Finale Verifikationskette**
+
+```bash
+uv run ruff check app tests && \
+uv run ruff format --check app tests && \
+uv run pytest -q
+```
+Expected:
+- `All checks passed!`
+- `62 files already formatted`
+- `207 passed`
+
+- [ ] **Step 2: Commit-Historie prüfen**
+
+```bash
+git log --oneline main..HEAD
+```
+Expected: 3 Commits (oder 5 falls Tasks 3–5 einzeln committet wurden — das ist ok, aber dann in Step 4 squashen oder so lassen, wie die User-Präferenz ist).
+
+- [ ] **Step 3: Push**
+
+```bash
+git push -u origin ruff-backlog-103
+```
+Expected: `Branch 'ruff-backlog-103' set up to track 'origin/ruff-backlog-103'`
+
+- [ ] **Step 4: PR erstellen**
+
+```bash
+gh pr create --title "Ruff-Backlog Cleanup + CI-Drift-Schutz (#103)" --body "$(cat <<'BODY'
+## Summary
+
+Behebt Issue #103 (Ruff-Backlog). Big-Bang-Cleanup aller 45 Lint-Violations (43× E501, 2× E402) und 13 Format-Drift-Files plus neuer CI-Workflow, der künftigen Drift auf PRs blockiert.
+
+## Commits
+
+- `chore: ruff format über app/ und tests/` — Reine Layout-Angleichung, 13 Files
+- `fix: Ruff-Lint-Violations (E501, E402) beheben` — 45 manuelle Fixes
+- `feat: CI-Workflow für Ruff-Gate auf PRs` — GitHub Action + `make lint-all`
+
+## Verifikation
+
+- [x] `uv run ruff check app tests` → All checks passed!
+- [x] `uv run ruff format --check app tests` → clean
+- [x] `uv run pytest` → 207 passed
+- [x] `make lint-all` → exit 0
+
+## Non-Goals
+
+Bewusst ausserhalb Scope: Weitere Ruff-Regeln (z.B. Docstring-Regeln), Pre-Commit-Hooks, Type-Checking (mypy). Kann später als separate Issues.
+
+Spec: \`docs/superpowers/specs/2026-04-21-ruff-backlog-design.md\`
+Closes #103.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+BODY
+)"
+```
+Expected: PR-URL wird ausgegeben.
+
+- [ ] **Step 5: CI-Run beobachten — der neue Lint-Workflow muss grün werden**
+
+```bash
+gh pr checks
+```
+Expected: `Lint / ruff` erscheint und läuft grün.
+
+Falls rot: Log lesen via `gh run view <run-id> --log-failed`, Ursache beheben, erneut pushen.
+
+- [ ] **Step 6: Code-Review anstossen (superpowers:requesting-code-review)**
+
+Der Review-Sub-Agent prüft Spec-Konsistenz, Dokumentation und OWASP. Bei reinen Lint-Changes wenig zu beanstanden, aber Protokoll ist Pflicht laut CLAUDE.md.
+
+- [ ] **Step 7: Nach Merge: Issue-Status, README, Memories**
+
+Nach Merge in `main`:
+
+```bash
+gh issue close 103 --comment "Behoben via PR (siehe verlinkter PR). CI-Gate aktiv auf allen künftigen PRs."
+git checkout main && git pull
+git branch -d ruff-backlog-103
+```
+
+Post-Merge-Hygiene (gemäss `feedback_pause_cleanup.md`):
+- GitHub Issues: #103 geschlossen, prüfen ob das andere Issues unblockt (sollte nicht, da "Blocks: nichts")
+- README: kein Update nötig (rein technische Hygiene)
+- Dokumentation: `docs/index.md` zeigt Spec bereits via Spec-Directory-Konvention
+- Memory: ggf. ein `project_ci_gates.md` anlegen mit Hinweis „Ruff-Check ist CI-Gate seit 2026-04-21"
+
+---
+
+## Summary der Commit-Struktur
+
+```
+chore: ruff format über app/ und tests/          (Task 2, 13 Files)
+fix:   Ruff-Lint-Violations (E501, E402) beheben (Tasks 3+4+5, 10 Files)
+feat:  CI-Workflow für Ruff-Gate auf PRs         (Task 6, 2 Files)
+```
+
+3 Commits im finalen PR — falls Tasks 3/4/5 einzeln committet wurden, vor Merge optional via `git rebase -i main` zu einem Commit squashen (nur falls User das explizit wünscht; ansonsten mehr Commits lassen ist auch ok).

--- a/docs/superpowers/specs/2026-04-21-ruff-backlog-design.md
+++ b/docs/superpowers/specs/2026-04-21-ruff-backlog-design.md
@@ -1,0 +1,135 @@
+# Ruff-Backlog Cleanup + Drift-Schutz — Design
+
+- **Issue:** #103
+- **Datum:** 2026-04-21
+- **Typ:** Hygiene (kein Feature, keine funktionale Änderung)
+
+## Problem
+
+`uv run ruff check app tests` meldet **45 Lint-Violations** (43× E501, 2× E402), `uv run ruff format --check app tests` meldet **13 Format-Drift-Files**. Alle pre-existing, kein Runtime-Effekt. Die Ursache: es gibt keine CI-Stufe, die Ruff bei PRs erzwingt — nur `deploy.yml` läuft automatisiert.
+
+Ohne Gate wird sich derselbe Drift nach dem Cleanup wieder ansammeln.
+
+## Ziel
+
+1. `ruff check app tests` und `ruff format --check app tests` beide clean.
+2. GitHub-Actions-Workflow, der ab sofort jeden Drift blockiert, bevor er auf `main` kommt.
+3. Keine funktionalen Änderungen — alle 207 Tests bleiben unverändert grün.
+
+## Nicht-Ziele
+
+- Weitere Ruff-Regeln aktivieren (z.B. `D`-Serie für Docstrings).
+- Pre-commit-Hooks (CI-Gate reicht).
+- Type-Checking (mypy/pyright) einführen.
+- `.git-blame-ignore-revs` pflegen (YAGNI bei dieser Grösse).
+
+## Scope
+
+Angefasste Bereiche:
+
+| Bereich | Dateien | Art der Änderung |
+|---|---|---|
+| `app/` | 7 Format-Drifts + 3 E501 | `ruff format` + manuelle Zeilenumbrüche |
+| `tests/` | 6 Format-Drifts + 40 E501 + 2 E402 | `ruff format` + manuelle Zeilenumbrüche + Import-Reorg |
+| `.github/workflows/` | 1 neue Datei | `lint.yml` |
+| `Makefile` | 1 Target | `lint-all` ergänzen |
+
+## Lösungsansatz
+
+Big-Bang-Cleanup in einem Pull Request mit drei semantisch getrennten Commits.
+
+### Commit 1 — `chore: ruff format über app/ und tests/`
+
+Ausführen: `uv run ruff format app tests`.
+
+Ergebnis: 13 Dateien umformatiert, ausschliesslich Layout-Änderungen (dict-Literale, Funktionsaufrufe inline vs. mehrzeilig). Kein menschliches Urteil, semantik-preserving.
+
+### Commit 2 — `fix: Ruff-Lint-Violations (E501, E402) beheben`
+
+Manuelle Fixes für die 45 Violations:
+
+**43× E501 (Zeile zu lang, >88 Zeichen)**
+- `app/routers/webhooks.py:142` — `details=json.dumps(...)` in Log-Aufruf brechen.
+- `app/services/stripe_service.py:48` — `success_url`-f-string auf zwei Zeilen.
+- `app/services/rabattcode_service.py:57` — Fehlermeldungs-f-string brechen.
+- 40× in `tests/` — mehrzeilige SQL-INSERTs und Docstrings umbrechen. Strategie:
+  - Mehrzeilige SQL-Strings via String-Literal-Concatenation (`"INSERT INTO ... " "VALUES ..."`), wobei jede Zeile ≤88 Zeichen bleibt.
+  - Docstrings auf eine Zeile verkürzen oder triple-quoted mehrzeilig.
+  - Assertion-Strings bei Bedarf in Variablen extrahieren.
+
+**2× E402 (Import nicht am Dateianfang) in `tests/test_rabattcode_service.py`**
+
+Beide Imports (`from app.repositories.rabattcode_repo import ...` und `from app.services.rabattcode_service import ...`) an den Datei-Kopf verschieben. Die vorhandenen Sektionsmarker `# --- Repository Tests ---` / `# --- Service Tests ---` bleiben als visuelle Trenner stehen.
+
+### Commit 3 — `feat: CI-Workflow für Ruff-Gate auf PRs`
+
+Neue Datei `.github/workflows/lint.yml`:
+
+```yaml
+name: Lint
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  ruff:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.13"
+      - name: Install dev dependencies
+        run: uv sync --extra dev
+      - name: Ruff Check
+        run: uv run ruff check app tests
+      - name: Ruff Format Check
+        run: uv run ruff format --check app tests
+```
+
+Zusätzlich in `Makefile` ein neues Target hinzufügen:
+
+```make
+lint-all: ## Ruff-Check + Format-Check (gleich wie CI)
+	uv run ruff check app tests
+	uv run ruff format --check app tests
+```
+
+Und in der `.PHONY`-Zeile `lint-all` ergänzen.
+
+## Design-Entscheidungen (mit Begründung)
+
+| Entscheidung | Warum |
+|---|---|
+| Big-Bang statt inkrementell | Projekt ist erst 6 Monate alt, ~60 Dateien → einmaliger Blame-Schmerz günstiger als dauerhafte Sonderregeln. |
+| `ruff format` zuerst in eigenem Commit | Reine Layout-Commits sind für Reviewer leicht überspringbar. |
+| E402 via Imports-nach-oben-ziehen (nicht `# noqa`) | Standard-Python-Idiom, weniger Sonderregeln. Kapitel-Struktur bleibt durch `# ---`-Kommentare erhalten. |
+| CI-Trigger `pull_request` + `push` auf `main` | Safety-Net, falls direkt auf `main` committet wird. |
+| CI-Scope `app tests` | Konsistent mit Akzeptanzkriterium des Issues. |
+| Kein Cache im CI-Job | Job läuft in <30s, Cache-Config lohnt nicht. |
+| `make lint-all` | Lokale Reproduktion des CI-Gates vor Push. |
+
+## Verifikation
+
+| Schritt | Erwartetes Ergebnis |
+|---|---|
+| `uv run ruff format --check app tests` | exit 0 |
+| `uv run ruff check app tests` | "All checks passed!" |
+| `uv run pytest` | alle 207 Tests grün |
+| `make lint-all` | exit 0 |
+| Neuer PR auf GitHub | `Lint`-Check-Job erscheint und läuft grün |
+
+## Rollback-Plan
+
+Falls ein Test nach dem `ruff format` rot wird (unerwartet — ruff format ist semantik-preserving):
+
+1. `git reset --hard` auf den Stand vor Commit 1.
+2. Pro Datei einzeln `ruff format <file>` laufen lassen + Tests prüfen.
+3. Problematische Datei via `per-file-ignores` ausschliessen und im Issue dokumentieren.
+
+## Offene Fragen
+
+Keine.

--- a/tests/test_abholung_bar.py
+++ b/tests/test_abholung_bar.py
@@ -49,7 +49,8 @@ def test_stakeholder_mail_wird_gesendet(mock_client):
 
 @patch("app.services.email_service.brevo_client")
 def test_bestellen_abholung_bar(mock_email, client):
-    """POST /bestellen mit zahlungsart=abholung_bar speichert Bestellung und sendet Mails."""
+    """POST /bestellen mit zahlungsart=abholung_bar speichert Bestellung und sendet
+    Mails."""
     import json
 
     from tests.conftest import _checkout_csrf

--- a/tests/test_api_admin.py
+++ b/tests/test_api_admin.py
@@ -73,12 +73,15 @@ def _insert_test_order(order_id=99):
     conn = get_db()
     try:
         conn.execute(
-            "INSERT INTO kunden (id, vorname, nachname, email, strasse, plz, ort) "
-            "VALUES (?, 'Test', 'Kunde', 'test@example.ch', 'Teststr 1', '3000', 'Bern')",
+            "INSERT INTO kunden "
+            "(id, vorname, nachname, email, strasse, plz, ort) "
+            "VALUES (?, 'Test', 'Kunde', 'test@example.ch', 'Teststr 1', "
+            "'3000', 'Bern')",
             (order_id,),
         )
         conn.execute(
-            "INSERT INTO bestellungen (id, kunde_id, zahlungsart, versandart, total_chf, status) "
+            "INSERT INTO bestellungen "
+            "(id, kunde_id, zahlungsart, versandart, total_chf, status) "
             "VALUES (?, ?, 'stripe', 'versand', 50.00, 'neu')",
             (order_id, order_id),
         )
@@ -176,7 +179,8 @@ class TestAdminStatusAenderung:
 
             # Verify log entry
             log = conn.execute(
-                "SELECT * FROM admin_log WHERE bestellung_id = ? AND aktion = 'status_geaendert'",
+                "SELECT * FROM admin_log "
+                "WHERE bestellung_id = ? AND aktion = 'status_geaendert'",
                 (order_id,),
             ).fetchone()
             assert log is not None
@@ -222,7 +226,8 @@ class TestAdminNotiz:
         conn = get_db()
         try:
             log = conn.execute(
-                "SELECT * FROM admin_log WHERE bestellung_id = ? AND aktion = 'notiz_hinzugefuegt'",
+                "SELECT * FROM admin_log "
+                "WHERE bestellung_id = ? AND aktion = 'notiz_hinzugefuegt'",
                 (order_id,),
             ).fetchone()
             assert log is not None

--- a/tests/test_api_admin.py
+++ b/tests/test_api_admin.py
@@ -35,7 +35,10 @@ class TestAdminLogin:
         assert "admin_session=" in set_cookie
         assert "Secure" in set_cookie
         assert "HttpOnly" in set_cookie
-        assert "SameSite=strict" in set_cookie.lower() or "samesite=strict" in set_cookie.lower()
+        assert (
+            "SameSite=strict" in set_cookie.lower()
+            or "samesite=strict" in set_cookie.lower()
+        )
 
     def test_login_wrong_password(self, admin_client):
         csrf = _login_csrf(admin_client)
@@ -116,9 +119,7 @@ class TestAdminDashboard:
 class TestEmailLogging:
     def test_email_service_logs_ausgang(self, db, monkeypatch):
         """After sending an email, an email_ausgang log entry should exist."""
-        monkeypatch.setattr(
-            "app.services.email_service.brevo_client", MagicMock()
-        )
+        monkeypatch.setattr("app.services.email_service.brevo_client", MagicMock())
 
         from app.services.email_service import sende_bestellbestaetigung
 

--- a/tests/test_api_rabattcodes.py
+++ b/tests/test_api_rabattcodes.py
@@ -3,7 +3,8 @@ def test_rabattcode_pruefen_gueltig(client):
 
     conn = get_db()
     conn.execute(
-        "INSERT INTO rabattcodes (code, rabattart, rabattwert, gueltig_von, gueltig_bis) "
+        "INSERT INTO rabattcodes "
+        "(code, rabattart, rabattwert, gueltig_von, gueltig_bis) "
         "VALUES ('AKTION10', 'prozent', 10.0, '2026-01-01', '2026-12-31')"
     )
     conn.commit()
@@ -35,7 +36,8 @@ def test_bestellung_mit_rabattcode(client, csrf_token):
 
     conn = get_db()
     conn.execute(
-        "INSERT INTO rabattcodes (code, rabattart, rabattwert, gueltig_von, gueltig_bis) "
+        "INSERT INTO rabattcodes "
+        "(code, rabattart, rabattwert, gueltig_von, gueltig_bis) "
         "VALUES ('WILLKOMMEN', 'fixbetrag', 5.0, '2026-01-01', '2026-12-31')"
     )
     conn.commit()

--- a/tests/test_api_rabattcodes.py
+++ b/tests/test_api_rabattcodes.py
@@ -1,5 +1,3 @@
-
-
 def test_rabattcode_pruefen_gueltig(client):
     from app.database import get_db
 
@@ -112,7 +110,9 @@ def _make_admin_client(tmp_path, monkeypatch):
     from fastapi.testclient import TestClient
 
     pw_hash = bcrypt.hashpw(b"testpass", bcrypt.gensalt()).decode()
-    monkeypatch.setattr("app.config.settings.database_path", str(tmp_path / "admin_test.db"))
+    monkeypatch.setattr(
+        "app.config.settings.database_path", str(tmp_path / "admin_test.db")
+    )
     monkeypatch.setattr("app.config.settings.admin_credentials", f"dev:{pw_hash}")
     monkeypatch.setattr("app.config.settings.cookie_secure", False)
     from app.database import init_db
@@ -129,9 +129,7 @@ def _admin_login(admin_client):
 
     get_resp = admin_client.get("/admin/login")
     csrf_id = get_resp.cookies.get("csrf_id", "")
-    csrf = generiere_csrf_token(
-        settings.secret_key, identity=f"anon:{csrf_id}"
-    )
+    csrf = generiere_csrf_token(settings.secret_key, identity=f"anon:{csrf_id}")
     resp = admin_client.post(
         "/admin/login",
         data={"password": "testpass", "csrf_token": csrf},

--- a/tests/test_api_seiten.py
+++ b/tests/test_api_seiten.py
@@ -5,7 +5,8 @@ def test_ueber_das_oel_status(client):
 
 
 def test_ueber_das_oel_inhalt(client):
-    """Die Seite enthält die vier Abschnitte mit neuen Titeln (ohne bestimmten Artikel)."""
+    """Die Seite enthält die vier Abschnitte mit neuen Titeln
+    (ohne bestimmten Artikel)."""
     response = client.get("/ueber-das-oel")
     assert "Unser Olivenöl" in response.text
     # Neue Titel ohne bestimmten Artikel (SH-Feedback 2026-04-21)
@@ -84,7 +85,8 @@ def test_ueber_das_oel_herkunft_text(client):
     assert "Nevadillo Blanco" in response.text
     assert "Berghainen" in response.text  # bewusst so gewählt (Hain am Berg)
     assert "Sierra Morena" in response.text
-    # "geerntet" ist neu (alter Text endete mit "von Hand gearbeitet, wie seit Generationen")
+    # "geerntet" ist neu (alter Text endete mit "von Hand gearbeitet,
+    # wie seit Generationen")
     assert "geerntet" in response.text
 
 

--- a/tests/test_api_webhooks.py
+++ b/tests/test_api_webhooks.py
@@ -75,9 +75,7 @@ def test_webhook_bestellung_nicht_gefunden(mock_construct, mock_email, client):
 
 @patch("app.services.email_service.brevo_client")
 @patch("app.routers.webhooks.stripe.Webhook.construct_event")
-def test_webhook_doppelt_kein_doppelte_email(
-    mock_construct, mock_email, client, db
-):
+def test_webhook_doppelt_kein_doppelte_email(mock_construct, mock_email, client, db):
     """Doppelter Webhook → E-Mail nur einmal, Status bleibt bezahlt."""
     # Testbestellung anlegen
     db.execute(
@@ -159,11 +157,12 @@ def test_webhook_checkout_expired_storniert_bestellung(mock_construct, client, d
     row = db.execute("SELECT status FROM bestellungen WHERE id = 1").fetchone()
     assert dict(row)["status"] == "storniert"
 
-    log = db.execute(
-        "SELECT * FROM admin_log WHERE bestellung_id = 1"
-    ).fetchone()
+    log = db.execute("SELECT * FROM admin_log WHERE bestellung_id = 1").fetchone()
     assert log is not None
-    assert "abgebrochen" in dict(log)["details"].lower() or "abgelaufen" in dict(log)["details"].lower()
+    assert (
+        "abgebrochen" in dict(log)["details"].lower()
+        or "abgelaufen" in dict(log)["details"].lower()
+    )
 
 
 @patch("app.routers.webhooks.stripe.Webhook.construct_event")
@@ -196,9 +195,7 @@ def test_webhook_payment_failed_storniert_bestellung(mock_construct, client, db)
     row = db.execute("SELECT status FROM bestellungen WHERE id = 1").fetchone()
     assert dict(row)["status"] == "storniert"
 
-    log = db.execute(
-        "SELECT * FROM admin_log WHERE bestellung_id = 1"
-    ).fetchone()
+    log = db.execute("SELECT * FROM admin_log WHERE bestellung_id = 1").fetchone()
     assert log is not None
     assert "fehlgeschlagen" in dict(log)["details"].lower()
 

--- a/tests/test_csrf.py
+++ b/tests/test_csrf.py
@@ -43,9 +43,7 @@ def test_token_ungueltig():
 def test_token_abgelaufen():
     token = generiere_csrf_token("secret", identity="x", max_age=-1)
     time.sleep(0.1)
-    assert not validiere_csrf_token(
-        token, "secret", expected_identity="x", max_age=-1
-    )
+    assert not validiere_csrf_token(token, "secret", expected_identity="x", max_age=-1)
 
 
 def test_admin_identity_stabil_und_unterschiedlich():
@@ -125,11 +123,16 @@ def test_bestellen_csrf_id_roundtrip(client):
 
     cart = json.dumps([{"produkt_id": 1, "menge": 1}])
     payload = {
-        "vorname": "Max", "nachname": "Muster",
-        "email": "max@test.ch", "strasse": "Str. 1",
-        "plz": "4600", "ort": "Olten",
-        "versandart": "abholung", "zahlungsart": "rechnung",
-        "cart_data": cart, "kommentar": "",
+        "vorname": "Max",
+        "nachname": "Muster",
+        "email": "max@test.ch",
+        "strasse": "Str. 1",
+        "plz": "4600",
+        "ort": "Olten",
+        "versandart": "abholung",
+        "zahlungsart": "rechnung",
+        "cart_data": cart,
+        "kommentar": "",
         "csrf_token": token,
     }
     resp = client.post("/bestellen", data=payload)
@@ -142,17 +145,23 @@ def test_bestellen_fremdes_token_abgelehnt(client):
     from app.config import settings
     from app.csrf import generiere_csrf_token
 
-    fremdes_token = generiere_csrf_token(
-        settings.secret_key, identity="anon:fremd"
-    )
+    fremdes_token = generiere_csrf_token(settings.secret_key, identity="anon:fremd")
     client.get("/checkout")
     cart = json.dumps([{"produkt_id": 1, "menge": 1}])
-    resp = client.post("/bestellen", data={
-        "vorname": "Max", "nachname": "Muster",
-        "email": "max@test.ch", "strasse": "Str. 1",
-        "plz": "4600", "ort": "Olten",
-        "versandart": "abholung", "zahlungsart": "rechnung",
-        "cart_data": cart, "kommentar": "",
-        "csrf_token": fremdes_token,
-    })
+    resp = client.post(
+        "/bestellen",
+        data={
+            "vorname": "Max",
+            "nachname": "Muster",
+            "email": "max@test.ch",
+            "strasse": "Str. 1",
+            "plz": "4600",
+            "ort": "Olten",
+            "versandart": "abholung",
+            "zahlungsart": "rechnung",
+            "cart_data": cart,
+            "kommentar": "",
+            "csrf_token": fremdes_token,
+        },
+    )
     assert resp.status_code == 403

--- a/tests/test_e2e_bestellzyklus.py
+++ b/tests/test_e2e_bestellzyklus.py
@@ -76,7 +76,8 @@ def test_e2e_stripe_flow(mock_stripe_create, mock_construct, mock_email, e2e_cli
     conn = get_db()
     try:
         row = conn.execute(
-            "SELECT id, status, stripe_session_id FROM bestellungen WHERE stripe_session_id = ?",
+            "SELECT id, status, stripe_session_id FROM bestellungen "
+            "WHERE stripe_session_id = ?",
             (stripe_session_id,),
         ).fetchone()
         assert row is not None
@@ -111,7 +112,8 @@ def test_e2e_stripe_flow(mock_stripe_create, mock_construct, mock_email, e2e_cli
 
         # Webhook-Log pruefen: neu -> bezahlt durch system
         log_webhook = conn.execute(
-            "SELECT * FROM admin_log WHERE bestellung_id = ? AND aktion = 'status_geaendert'",
+            "SELECT * FROM admin_log "
+            "WHERE bestellung_id = ? AND aktion = 'status_geaendert'",
             (bestell_id,),
         ).fetchone()
         assert log_webhook is not None
@@ -163,7 +165,8 @@ def test_e2e_stripe_flow(mock_stripe_create, mock_construct, mock_email, e2e_cli
 
         # Alle Status-Aenderungen chronologisch
         logs = conn.execute(
-            "SELECT * FROM admin_log WHERE bestellung_id = ? AND aktion = 'status_geaendert' "
+            "SELECT * FROM admin_log "
+            "WHERE bestellung_id = ? AND aktion = 'status_geaendert' "
             "ORDER BY zeitpunkt ASC",
             (bestell_id,),
         ).fetchall()
@@ -219,7 +222,8 @@ def test_e2e_rechnungs_flow(mock_email, mock_qr, e2e_client):
     # Rechnung liefert direkt die Bestaetigungsseite (Status 200)
     assert resp_bestellen.status_code == 200
     assert "bestell" in resp_bestellen.text.lower()
-    # Beim Rechnungs-Checkout: 2 E-Mails (Kundenbestätigung + Stakeholder-Benachrichtigung)
+    # Beim Rechnungs-Checkout: 2 E-Mails
+    # (Kundenbestätigung + Stakeholder-Benachrichtigung)
     assert mock_email.transactional_emails.send_transac_email.call_count == 2
 
     # Bestellung in DB pruefen
@@ -265,7 +269,8 @@ def test_e2e_rechnungs_flow(mock_email, mock_qr, e2e_client):
     )
     assert resp_status1.status_code == 303
 
-    # Zahlungseingangs-E-Mail muss gesendet worden sein (3. Aufruf, nach 2 Checkout-Mails)
+    # Zahlungseingangs-E-Mail muss gesendet worden sein
+    # (3. Aufruf, nach 2 Checkout-Mails)
     assert mock_email.transactional_emails.send_transac_email.call_count == 3
     dritter_call = mock_email.transactional_emails.send_transac_email.call_args_list[
         2
@@ -300,7 +305,8 @@ def test_e2e_rechnungs_flow(mock_email, mock_qr, e2e_client):
 
         # Alle Status-Aenderungen chronologisch
         logs = conn.execute(
-            "SELECT * FROM admin_log WHERE bestellung_id = ? AND aktion = 'status_geaendert' "
+            "SELECT * FROM admin_log "
+            "WHERE bestellung_id = ? AND aktion = 'status_geaendert' "
             "ORDER BY zeitpunkt ASC",
             (bestell_id,),
         ).fetchall()
@@ -372,7 +378,8 @@ def test_e2e_storno_nach_zahlung(
     conn = get_db()
     try:
         row = conn.execute(
-            "SELECT id, status, stripe_session_id FROM bestellungen WHERE stripe_session_id = ?",
+            "SELECT id, status, stripe_session_id FROM bestellungen "
+            "WHERE stripe_session_id = ?",
             (stripe_session_id,),
         ).fetchone()
         assert row is not None
@@ -438,7 +445,8 @@ def test_e2e_storno_nach_zahlung(
 
         # Genau 2 Log-Eintraege in chronologischer Reihenfolge
         logs = conn.execute(
-            "SELECT * FROM admin_log WHERE bestellung_id = ? AND aktion = 'status_geaendert' "
+            "SELECT * FROM admin_log "
+            "WHERE bestellung_id = ? AND aktion = 'status_geaendert' "
             "ORDER BY zeitpunkt ASC",
             (bestell_id,),
         ).fetchall()
@@ -561,7 +569,8 @@ def test_e2e_abholung_bar_flow(mock_email, e2e_client):
         assert row["status"] == "bezahlt"
 
         logs = conn.execute(
-            "SELECT * FROM admin_log WHERE bestellung_id = ? AND aktion = 'status_geaendert' "
+            "SELECT * FROM admin_log "
+            "WHERE bestellung_id = ? AND aktion = 'status_geaendert' "
             "ORDER BY zeitpunkt ASC",
             (bestell_id,),
         ).fetchall()

--- a/tests/test_email_service.py
+++ b/tests/test_email_service.py
@@ -50,8 +50,10 @@ class TestSendeStatusEmail:
     def _make_bestellung(self, db, zahlungsart="rechnung", versandart="versand"):
         """Hilfsfunktion: Kunde + Bestellung in DB anlegen."""
         db.execute(
-            "INSERT INTO kunden (id, vorname, nachname, email, telefon, strasse, plz, ort) "
-            "VALUES (1, 'Max', 'Muster', 'max@test.ch', '', 'Teststr 1', '8000', 'Zürich')"
+            "INSERT INTO kunden "
+            "(id, vorname, nachname, email, telefon, strasse, plz, ort) "
+            "VALUES (1, 'Max', 'Muster', 'max@test.ch', '', "
+            "'Teststr 1', '8000', 'Zürich')"
         )
         db.execute(
             "INSERT INTO bestellungen (id, kunde_id, status, zahlungsart, versandart, "
@@ -133,7 +135,8 @@ class TestSendeStatusEmail:
             mock_client.transactional_emails.send_transac_email.assert_not_called()
 
     def test_bezahlt_abholung_bar_sendet_email(self, db):
-        """bezahlt + abholung_bar → Zahlungseingangsbestätigung (Admin hat Bar-Zahlung bestätigt)."""
+        """bezahlt + abholung_bar → Zahlungseingangsbestätigung
+        (Admin hat Bar-Zahlung bestätigt)."""
         self._make_bestellung(db, zahlungsart="abholung_bar", versandart="abholung")
         with patch("app.services.email_service.brevo_client") as mock_client:
             mock_client.transactional_emails.send_transac_email.return_value = (

--- a/tests/test_email_service.py
+++ b/tests/test_email_service.py
@@ -65,12 +65,14 @@ class TestSendeStatusEmail:
         """bezahlt + rechnung → Zahlungseingangsbestätigung."""
         self._make_bestellung(db, zahlungsart="rechnung")
         with patch("app.services.email_service.brevo_client") as mock_client:
-            mock_client.transactional_emails.send_transac_email.return_value = MagicMock(
-                message_id="s1"
+            mock_client.transactional_emails.send_transac_email.return_value = (
+                MagicMock(message_id="s1")
             )
             sende_status_email(bestellung_id=1, neuer_status="bezahlt", conn=db)
             mock_client.transactional_emails.send_transac_email.assert_called_once()
-            call_kwargs = mock_client.transactional_emails.send_transac_email.call_args.kwargs
+            call_kwargs = (
+                mock_client.transactional_emails.send_transac_email.call_args.kwargs
+            )
             assert call_kwargs["to"][0]["email"] == "max@test.ch"
             assert "Zahlungseingang" in call_kwargs["subject"]
 
@@ -85,12 +87,14 @@ class TestSendeStatusEmail:
         """versendet + versand → Versandbestätigung."""
         self._make_bestellung(db, versandart="versand")
         with patch("app.services.email_service.brevo_client") as mock_client:
-            mock_client.transactional_emails.send_transac_email.return_value = MagicMock(
-                message_id="s2"
+            mock_client.transactional_emails.send_transac_email.return_value = (
+                MagicMock(message_id="s2")
             )
             sende_status_email(bestellung_id=1, neuer_status="versendet", conn=db)
             mock_client.transactional_emails.send_transac_email.assert_called_once()
-            call_kwargs = mock_client.transactional_emails.send_transac_email.call_args.kwargs
+            call_kwargs = (
+                mock_client.transactional_emails.send_transac_email.call_args.kwargs
+            )
             assert "unterwegs" in call_kwargs["subject"]
 
     def test_versendet_abholung_keine_email(self, db):
@@ -104,12 +108,14 @@ class TestSendeStatusEmail:
         """abholbereit + abholung → Abholbenachrichtigung."""
         self._make_bestellung(db, versandart="abholung")
         with patch("app.services.email_service.brevo_client") as mock_client:
-            mock_client.transactional_emails.send_transac_email.return_value = MagicMock(
-                message_id="s3"
+            mock_client.transactional_emails.send_transac_email.return_value = (
+                MagicMock(message_id="s3")
             )
             sende_status_email(bestellung_id=1, neuer_status="abholbereit", conn=db)
             mock_client.transactional_emails.send_transac_email.assert_called_once()
-            call_kwargs = mock_client.transactional_emails.send_transac_email.call_args.kwargs
+            call_kwargs = (
+                mock_client.transactional_emails.send_transac_email.call_args.kwargs
+            )
             assert "abholbereit" in call_kwargs["subject"]
 
     def test_abholbereit_versand_keine_email(self, db):
@@ -130,10 +136,12 @@ class TestSendeStatusEmail:
         """bezahlt + abholung_bar → Zahlungseingangsbestätigung (Admin hat Bar-Zahlung bestätigt)."""
         self._make_bestellung(db, zahlungsart="abholung_bar", versandart="abholung")
         with patch("app.services.email_service.brevo_client") as mock_client:
-            mock_client.transactional_emails.send_transac_email.return_value = MagicMock(
-                message_id="s_bar"
+            mock_client.transactional_emails.send_transac_email.return_value = (
+                MagicMock(message_id="s_bar")
             )
             sende_status_email(bestellung_id=1, neuer_status="bezahlt", conn=db)
             mock_client.transactional_emails.send_transac_email.assert_called_once()
-            call_kwargs = mock_client.transactional_emails.send_transac_email.call_args.kwargs
+            call_kwargs = (
+                mock_client.transactional_emails.send_transac_email.call_args.kwargs
+            )
             assert "Zahlungseingang" in call_kwargs["subject"]

--- a/tests/test_rabattcode_service.py
+++ b/tests/test_rabattcode_service.py
@@ -1,5 +1,3 @@
-
-
 # --- Migration Tests ---
 
 
@@ -35,7 +33,9 @@ def test_code_einloesungen_tabelle_existiert(db):
         "VALUES (1, 'test@example.com', 1)"
     )
     db.commit()
-    row = db.execute("SELECT * FROM code_einloesungen WHERE email = 'test@example.com'").fetchone()
+    row = db.execute(
+        "SELECT * FROM code_einloesungen WHERE email = 'test@example.com'"
+    ).fetchone()
     assert row is not None
 
 
@@ -50,7 +50,9 @@ def test_bestellungen_hat_rabattfelder(db):
         "VALUES (1, 'stripe', 'versand', 9.90, 20.90, NULL, 5.00)"
     )
     db.commit()
-    row = db.execute("SELECT rabattbetrag_chf FROM bestellungen WHERE id = 1").fetchone()
+    row = db.execute(
+        "SELECT rabattbetrag_chf FROM bestellungen WHERE id = 1"
+    ).fetchone()
     assert row["rabattbetrag_chf"] == 5.00
 
 
@@ -68,8 +70,12 @@ from app.repositories.rabattcode_repo import (
 
 def test_rabattcode_anlegen_und_laden(db):
     code_id = rabattcode_anlegen(
-        db, code="SOMMER20", rabattart="prozent", rabattwert=20.0,
-        gueltig_von="2026-06-01", gueltig_bis="2026-08-31",
+        db,
+        code="SOMMER20",
+        rabattart="prozent",
+        rabattwert=20.0,
+        gueltig_von="2026-06-01",
+        gueltig_bis="2026-08-31",
     )
     assert code_id > 0
     loaded = rabattcode_laden(db, code_id)
@@ -79,8 +85,12 @@ def test_rabattcode_anlegen_und_laden(db):
 
 def test_rabattcode_laden_by_code(db):
     rabattcode_anlegen(
-        db, code="HERBST5", rabattart="fixbetrag", rabattwert=5.0,
-        gueltig_von="2026-09-01", gueltig_bis="2026-11-30",
+        db,
+        code="HERBST5",
+        rabattart="fixbetrag",
+        rabattwert=5.0,
+        gueltig_von="2026-09-01",
+        gueltig_bis="2026-11-30",
     )
     loaded = rabattcode_laden_by_code(db, "herbst5")
     assert loaded is not None
@@ -89,8 +99,12 @@ def test_rabattcode_laden_by_code(db):
 
 def test_einloesung_speichern_und_pruefen(db):
     code_id = rabattcode_anlegen(
-        db, code="EINMAL", rabattart="fixbetrag", rabattwert=5.0,
-        gueltig_von="2026-01-01", gueltig_bis="2026-12-31",
+        db,
+        code="EINMAL",
+        rabattart="fixbetrag",
+        rabattwert=5.0,
+        gueltig_von="2026-01-01",
+        gueltig_bis="2026-12-31",
     )
     db.execute(
         "INSERT INTO kunden (vorname, nachname, email, strasse, plz, ort) "
@@ -116,14 +130,18 @@ from app.services.rabattcode_service import berechne_rabatt, pruefe_rabattcode
 def test_berechne_rabatt_prozent():
     assert berechne_rabatt("prozent", 10.0, 26.00) == 2.60
 
+
 def test_berechne_rabatt_prozent_5rappen_rundung():
     assert berechne_rabatt("prozent", 7.0, 18.00) == 1.25
+
 
 def test_berechne_rabatt_fixbetrag():
     assert berechne_rabatt("fixbetrag", 5.0, 26.00) == 5.00
 
+
 def test_berechne_rabatt_fixbetrag_nicht_mehr_als_subtotal():
     assert berechne_rabatt("fixbetrag", 50.0, 26.00) == 26.00
+
 
 def test_berechne_rabatt_prozent_5rappen_weitere():
     assert berechne_rabatt("prozent", 15.0, 8.00) == 1.20
@@ -134,11 +152,15 @@ def test_berechne_rabatt_prozent_5rappen_weitere():
 # Helper functions for pruefe_rabattcode tests
 def _erstelle_testcode(db, **overrides):
     defaults = {
-        "code": "TEST10", "rabattart": "prozent", "rabattwert": 10.0,
-        "gueltig_von": "2026-01-01", "gueltig_bis": "2026-12-31",
+        "code": "TEST10",
+        "rabattart": "prozent",
+        "rabattwert": 10.0,
+        "gueltig_von": "2026-01-01",
+        "gueltig_bis": "2026-12-31",
     }
     defaults.update(overrides)
     return rabattcode_anlegen(db, **defaults)
+
 
 def _erstelle_testbestellung(db):
     db.execute(
@@ -158,9 +180,11 @@ def test_pruefe_rabattcode_gueltig(db):
     assert result["gueltig"] is True
     assert result["rabattbetrag"] == 2.60
 
+
 def test_pruefe_rabattcode_unbekannt(db):
     result = pruefe_rabattcode(db, "GIBTSNICHT", "kunde@test.ch", 26.00)
     assert result["gueltig"] is False
+
 
 def test_pruefe_rabattcode_deaktiviert(db):
     code_id = _erstelle_testcode(db)
@@ -169,16 +193,19 @@ def test_pruefe_rabattcode_deaktiviert(db):
     result = pruefe_rabattcode(db, "TEST10", "kunde@test.ch", 26.00)
     assert result["gueltig"] is False
 
+
 def test_pruefe_rabattcode_abgelaufen(db):
     _erstelle_testcode(db, gueltig_von="2025-01-01", gueltig_bis="2025-12-31")
     result = pruefe_rabattcode(db, "TEST10", "kunde@test.ch", 26.00)
     assert result["gueltig"] is False
     assert "abgelaufen" in result["fehler"].lower()
 
+
 def test_pruefe_rabattcode_noch_nicht_gueltig(db):
     _erstelle_testcode(db, gueltig_von="2027-01-01", gueltig_bis="2027-12-31")
     result = pruefe_rabattcode(db, "TEST10", "kunde@test.ch", 26.00)
     assert result["gueltig"] is False
+
 
 def test_pruefe_rabattcode_max_einloesungen_erreicht(db):
     _erstelle_testcode(db, max_einloesungen=1)
@@ -188,6 +215,7 @@ def test_pruefe_rabattcode_max_einloesungen_erreicht(db):
     assert result["gueltig"] is False
     assert "aufgebraucht" in result["fehler"].lower()
 
+
 def test_pruefe_rabattcode_bereits_eingeloest(db):
     code_id = _erstelle_testcode(db)
     _erstelle_testbestellung(db)
@@ -196,11 +224,13 @@ def test_pruefe_rabattcode_bereits_eingeloest(db):
     assert result["gueltig"] is False
     assert "bereits" in result["fehler"].lower()
 
+
 def test_pruefe_rabattcode_mindestbestellwert_nicht_erreicht(db):
     _erstelle_testcode(db, mindestbestellwert_chf=50.0)
     result = pruefe_rabattcode(db, "TEST10", "kunde@test.ch", 26.00)
     assert result["gueltig"] is False
     assert "mindestbestellwert" in result["fehler"].lower()
+
 
 def test_pruefe_rabattcode_mindestbestellwert_erreicht(db):
     _erstelle_testcode(db, mindestbestellwert_chf=25.0)

--- a/tests/test_rabattcode_service.py
+++ b/tests/test_rabattcode_service.py
@@ -1,9 +1,19 @@
+from app.repositories.rabattcode_repo import (
+    einloesung_speichern,
+    ist_bereits_eingeloest,
+    rabattcode_anlegen,
+    rabattcode_laden,
+    rabattcode_laden_by_code,
+)
+from app.services.rabattcode_service import berechne_rabatt, pruefe_rabattcode
+
 # --- Migration Tests ---
 
 
 def test_rabattcodes_tabelle_existiert(db):
     db.execute(
-        "INSERT INTO rabattcodes (code, rabattart, rabattwert, gueltig_von, gueltig_bis) "
+        "INSERT INTO rabattcodes "
+        "(code, rabattart, rabattwert, gueltig_von, gueltig_bis) "
         "VALUES ('TEST10', 'prozent', 10.0, '2026-01-01', '2026-12-31')"
     )
     db.commit()
@@ -16,7 +26,8 @@ def test_rabattcodes_tabelle_existiert(db):
 
 def test_code_einloesungen_tabelle_existiert(db):
     db.execute(
-        "INSERT INTO rabattcodes (code, rabattart, rabattwert, gueltig_von, gueltig_bis) "
+        "INSERT INTO rabattcodes "
+        "(code, rabattart, rabattwert, gueltig_von, gueltig_bis) "
         "VALUES ('TEST5', 'fixbetrag', 5.0, '2026-01-01', '2026-12-31')"
     )
     db.execute(
@@ -24,7 +35,8 @@ def test_code_einloesungen_tabelle_existiert(db):
         "VALUES ('Test', 'User', 'test@example.com', 'Teststr. 1', '4600', 'Olten')"
     )
     db.execute(
-        "INSERT INTO bestellungen (kunde_id, zahlungsart, versandart, versandkosten_chf, total_chf) "
+        "INSERT INTO bestellungen "
+        "(kunde_id, zahlungsart, versandart, versandkosten_chf, total_chf) "
         "VALUES (1, 'stripe', 'versand', 9.90, 25.90)"
     )
     db.commit()
@@ -45,7 +57,8 @@ def test_bestellungen_hat_rabattfelder(db):
         "VALUES ('Test', 'User', 'test@example.com', 'Teststr. 1', '4600', 'Olten')"
     )
     db.execute(
-        "INSERT INTO bestellungen (kunde_id, zahlungsart, versandart, versandkosten_chf, "
+        "INSERT INTO bestellungen "
+        "(kunde_id, zahlungsart, versandart, versandkosten_chf, "
         "total_chf, rabattcode_id, rabattbetrag_chf) "
         "VALUES (1, 'stripe', 'versand', 9.90, 20.90, NULL, 5.00)"
     )
@@ -57,15 +70,6 @@ def test_bestellungen_hat_rabattfelder(db):
 
 
 # --- Repository Tests ---
-
-
-from app.repositories.rabattcode_repo import (
-    einloesung_speichern,
-    ist_bereits_eingeloest,
-    rabattcode_anlegen,
-    rabattcode_laden,
-    rabattcode_laden_by_code,
-)
 
 
 def test_rabattcode_anlegen_und_laden(db):
@@ -111,7 +115,8 @@ def test_einloesung_speichern_und_pruefen(db):
         "VALUES ('A', 'B', 'a@b.ch', 'Str. 1', '4600', 'Olten')"
     )
     db.execute(
-        "INSERT INTO bestellungen (kunde_id, zahlungsart, versandart, versandkosten_chf, total_chf) "
+        "INSERT INTO bestellungen "
+        "(kunde_id, zahlungsart, versandart, versandkosten_chf, total_chf) "
         "VALUES (1, 'stripe', 'versand', 0, 50)"
     )
     db.commit()
@@ -123,8 +128,6 @@ def test_einloesung_speichern_und_pruefen(db):
 
 
 # --- Service Tests ---
-
-from app.services.rabattcode_service import berechne_rabatt, pruefe_rabattcode
 
 
 def test_berechne_rabatt_prozent():
@@ -168,7 +171,8 @@ def _erstelle_testbestellung(db):
         "VALUES ('A', 'B', 'a@b.ch', 'Str. 1', '4600', 'Olten')"
     )
     db.execute(
-        "INSERT INTO bestellungen (kunde_id, zahlungsart, versandart, versandkosten_chf, total_chf) "
+        "INSERT INTO bestellungen "
+        "(kunde_id, zahlungsart, versandart, versandkosten_chf, total_chf) "
         "VALUES (1, 'stripe', 'versand', 0, 50)"
     )
     db.commit()


### PR DESCRIPTION
## Summary

Behebt Issue #103 (Ruff-Backlog). Big-Bang-Cleanup aller 45 Lint-Violations und 13 Format-Drift-Files, plus neuer CI-Workflow der künftigen Drift auf PRs blockiert.

## Commits

- \`chore: ruff format über app/ und tests/\` — 13 Format-Drift-Files, rein Layout
- \`fix: Ruff-Lint-Violations (E501, E402) beheben\` — 41 manuelle Lint-Fixes
- \`feat: CI-Workflow für Ruff-Gate auf PRs\` — GitHub Action + \`make lint-all\`

(Zusätzlich: 2 Doc-Commits für Spec und Implementation-Plan)

## Verifikation

- \`uv run ruff check app tests\` → All checks passed!
- \`uv run ruff format --check app tests\` → 62 files already formatted
- \`uv run pytest\` → 207 passed
- \`make lint-all\` → exit 0

## Anmerkung zu Zahlen

Der Plan hatte 45 Violations erwartet (43× E501 + 2× E402). Effektiv waren nach \`ruff format\` noch 41 übrig (2 E501-Stellen wurden durch ruff format bereits auto-behoben), was zusammen mit den 2 E402 die 43 im Commit-Message erklärt.

## Non-Goals

Bewusst ausserhalb Scope: weitere Ruff-Regeln (Docstring-Serie), Pre-commit-Hooks, mypy/pyright.

**Spec:** \`docs/superpowers/specs/2026-04-21-ruff-backlog-design.md\`
**Plan:** \`docs/superpowers/plans/2026-04-21-issue-103-ruff-backlog.md\`

Closes #103.

🤖 Generated with [Claude Code](https://claude.com/claude-code)