### PR TITLE
CI-Hardening: SHA-Pinning + README-Entwickler-Guide (#105)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,7 @@ updates:
     labels:
       - "dependencies"
       - "github-actions"
+    groups:
+      docker-actions:
+        patterns:
+          - "docker/*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"
+    labels:
+      - "dependencies"
+      - "github-actions"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -108,7 +108,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: superfly/flyctl-actions/setup-flyctl@ed8efb33836e8b2096c7fd3ba1c8afe303ebbff1  # v1.6
+      - uses: superfly/flyctl-actions/setup-flyctl@ed8efb33836e8b2096c7fd3ba1c8afe303ebbff1  # 1.6
 
       - name: Deploy ${{ needs.build.outputs.app_version }} to fly.io
         run: flyctl deploy --app olivalle --image ${{ needs.build.outputs.image_sha }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,10 +20,10 @@ jobs:
     name: Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5.4.2
         with:
           python-version: "3.13"
 
@@ -44,7 +44,7 @@ jobs:
       image_sha: ${{ steps.image_ref.outputs.ref }}
       app_version: ${{ env.APP_VERSION }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         with:
           fetch-depth: 0
 
@@ -65,22 +65,22 @@ jobs:
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051  # v5.10.0
         with:
           images: ghcr.io/konstantinniedermann/olivalle
           tags: |
             type=sha,prefix=
             type=raw,value=latest
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3.12.0
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3.7.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6.19.2
         with:
           context: .
           push: true
@@ -104,11 +104,11 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         with:
           fetch-depth: 0
 
-      - uses: superfly/flyctl-actions/setup-flyctl@v1
+      - uses: superfly/flyctl-actions/setup-flyctl@ed8efb33836e8b2096c7fd3ba1c8afe303ebbff1  # v1.6
 
       - name: Deploy ${{ needs.build.outputs.app_version }} to fly.io
         run: flyctl deploy --app olivalle --image ${{ needs.build.outputs.image_sha }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,8 +12,8 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+      - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5.4.2
         with:
           python-version: "3.13"
       - name: Install dev dependencies

--- a/README.md
+++ b/README.md
@@ -63,3 +63,16 @@ make css-watch
 ```
 
 **Docker-Deployment:** Der Multi-Stage-Build im `Dockerfile` enthält eine Node-Stage, die Tailwind automatisch baut. Lokales `npm install` ist für Deployment nicht nötig — nur für die lokale Entwicklung.
+
+---
+
+## Entwicklung
+
+Vor jedem Push empfohlen:
+
+```bash
+make lint-all   # Ruff-Check + Format-Check (identisch zum CI-Gate)
+make test       # Tests via pytest
+```
+
+Eine Übersicht aller verfügbaren Kommandos liefert `make help`.

--- a/docs/arc42.md
+++ b/docs/arc42.md
@@ -211,6 +211,9 @@ graph TD
 ### Build-Prozess
 Das Docker-Image wird als Multi-Stage-Build erzeugt: Eine Node-Stage kompiliert Tailwind CSS zur Build-Zeit zu einer statischen Datei (`static/css/app.css`), die Python-Stage kopiert nur das fertige CSS-Artefakt. Dadurch wird kein Tailwind-CDN und keine Runtime-JIT mehr benötigt — die Content Security Policy kommt ohne `unsafe-eval` aus.
 
+### Qualitätsgate
+Vor dem Push wird lokal `make lint-all` (Ruff-Check + Format-Check) und `make test` (pytest) ausgeführt; identische Checks laufen als CI-Gate (`.github/workflows/lint.yml`, `deploy.yml`). GitHub Actions sind SHA-gepinnt (Schutz gegen Tag-Mutation, OWASP CICD-SEC-4) und werden via Dependabot wöchentlich aktualisiert.
+
 ---
 
 ## 8. Querschnittliche Konzepte


### PR DESCRIPTION
Closes #105

## Summary
- **SHA-Pinning aller GitHub Actions** in `lint.yml` + `deploy.yml` (10 `uses:`-Zeilen) — 40-stellige Commit-SHAs mit `# vX.Y.Z`-Kommentar. Schutz gegen Tag-Mutation (OWASP CICD-SEC-4, Poisoned Pipeline Execution).
- **`.github/dependabot.yml`** neu angelegt (`package-ecosystem: github-actions`, wöchentlich), damit die Pins über Dependabot-PRs aktuell bleiben.
- **README-Abschnitt "Entwicklung"** mit `make lint-all` / `make test` als Pre-Push-Routine + Verweis auf `make help`.

## Konkret gepinnte Versionen
| Action | Version |
|---|---|
| `actions/checkout` | v4.3.1 |
| `astral-sh/setup-uv` | v5.4.2 |
| `docker/metadata-action` | v5.10.0 |
| `docker/setup-buildx-action` | v3.12.0 |
| `docker/login-action` | v3.7.0 |
| `docker/build-push-action` | v6.19.2 |
| `superfly/flyctl-actions/setup-flyctl` | v1.6 |

Major-Versionen wurden **nicht** erhöht — Dependabot schlägt künftige Upgrades als separate PRs vor.

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` für lint.yml, deploy.yml, dependabot.yml → YAML OK
- [x] `make lint-all` lokal → all checks passed
- [x] `make test` lokal → 207 passed
- [ ] CI-Lauf auf diesem PR (Lint-Gate + ggf. Deploy-Tests-Job) grün
- [ ] Nach Merge auf `main`: Deploy-Pipeline läuft mit gepinnten SHAs sauber durch

🤖 Generated with [Claude Code](https://claude.com/claude-code)