### PR TITLE
feat: SQLite-Backup via Litestream + Tigris (#110)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,3 +22,8 @@ jobs:
         run: uv run ruff check app tests
       - name: Ruff Format Check
         run: uv run ruff format --check app tests
+      - name: ShellCheck
+        uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38  # 2.0.0 (tag has no v-prefix)
+        with:
+          scandir: '.'
+          additional_files: 'entrypoint.sh'

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,13 +19,26 @@ RUN pip install --no-cache-dir .
 COPY . .
 COPY --from=css-builder /build/static/css/app.css ./static/css/app.css
 
+# Litestream-Binary installieren (pinned, analog zum SHA-Pinning-Grundsatz).
+# Architektur via TARGETARCH damit fly sowohl amd64 als auch arm64 deployen kann.
+ARG LITESTREAM_VERSION=0.3.13
+ARG TARGETARCH=amd64
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends curl ca-certificates \
+ && curl -fsSL "https://github.com/benbjohnson/litestream/releases/download/v${LITESTREAM_VERSION}/litestream-v${LITESTREAM_VERSION}-linux-${TARGETARCH}.tar.gz" \
+      | tar -xzC /usr/local/bin \
+ && apt-get purge -y curl \
+ && apt-get autoremove -y \
+ && rm -rf /var/lib/apt/lists/*
+
+COPY litestream.yml /etc/litestream.yml
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
 EXPOSE 8000
 
 ARG APP_VERSION=dev
 ENV APP_VERSION=${APP_VERSION}
 
-# DB-Migration beim Container-Start (nicht Build), damit sie auf das persistente Volume schreibt
-# --proxy-headers / --forwarded-allow-ips='*': hinter Fly-Proxy nötig, damit uvicorn
-# X-Forwarded-Proto auswertet. Sonst baut Starlettes url_for()/307-Redirects absolute
-# http://-URLs → Mixed Content blockt CSS, /admin redirected auf http.
-CMD ["sh", "-c", "python -c 'from app.database import init_db; init_db()' && uvicorn app.main:app --host 0.0.0.0 --port 8000 --proxy-headers --forwarded-allow-ips=*"]
+# Migrationen + uvicorn werden von entrypoint.sh orchestriert.
+ENTRYPOINT ["/entrypoint.sh"]

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .DEFAULT_GOAL := help
 
-.PHONY: help dev test lint lint-all format migrate docs css-build css-watch
+.PHONY: help dev test lint lint-all shellcheck format migrate docs css-build css-watch
 
 help: ## Alle verfügbaren Befehle anzeigen
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-15s\033[0m %s\n", $$1, $$2}'
@@ -23,9 +23,13 @@ lint: ## Linting (Ruff)
 format: ## Code formatieren (Ruff)
 	uv run ruff format .
 
-lint-all: ## Ruff-Check + Format-Check (gleich wie CI)
+lint-all: ## Ruff-Check + Format-Check + shellcheck (gleich wie CI)
 	uv run ruff check app tests
 	uv run ruff format --check app tests
+	shellcheck entrypoint.sh
+
+shellcheck: ## Shell-Skripte statisch prüfen
+	shellcheck entrypoint.sh
 
 migrate: ## Datenbank-Migration ausführen
 	uv run python -c "from app.database import init_db; init_db()"

--- a/README.md
+++ b/README.md
@@ -27,8 +27,9 @@ Entscheidungsgrundlagen siehe [`docs/arc42.md`](docs/arc42.md) und die ADRs unte
 ## Backups & Wiederherstellung
 
 Die SQLite-DB wird kontinuierlich via [Litestream](https://litestream.io)
-nach einem Tigris-Bucket (Region Paris) repliziert. Im Katastrophenfall
-(Volume-Verlust) restored der Container automatisch beim Start.
+in einen Tigris-Bucket (EU-Multi-Region: Amsterdam + Frankfurt) repliziert.
+Im Katastrophenfall (Volume-Verlust) restored der Container automatisch
+beim Start.
 
 - Architekturentscheidung: [`docs/adr-backup-strategie.md`](docs/adr-backup-strategie.md)
 - Restore-Anleitung: [`docs/runbook-restore.md`](docs/runbook-restore.md)

--- a/README.md
+++ b/README.md
@@ -24,6 +24,17 @@ Entscheidungsgrundlagen siehe [`docs/arc42.md`](docs/arc42.md) und die ADRs unte
 
 ---
 
+## Backups & Wiederherstellung
+
+Die SQLite-DB wird kontinuierlich via [Litestream](https://litestream.io)
+nach einem Tigris-Bucket (Region Paris) repliziert. Im Katastrophenfall
+(Volume-Verlust) restored der Container automatisch beim Start.
+
+- Architekturentscheidung: [`docs/adr-backup-strategie.md`](docs/adr-backup-strategie.md)
+- Restore-Anleitung: [`docs/runbook-restore.md`](docs/runbook-restore.md)
+
+---
+
 ## Projekt-Kontext
 
 Erstes eigenes Webprojekt im Rahmen des **CAS AI-Supported Software Engineering (AISE)** an der FFHS. Gebaut für einen Freund als Einzelunternehmer-Shop. Der gesamte Entwicklungsprozess lief unter Einsatz von **Claude Code** und einem formalen Agentic-Workflow (Brainstorming → Writing Plans → TDD → Code Review → Merge) über das [`superpowers`](https://github.com/obra/superpowers)-Plugin.

--- a/docs/adr-backup-strategie.md
+++ b/docs/adr-backup-strategie.md
@@ -1,0 +1,65 @@
+# ADR: Backup-Strategie — Litestream + Tigris
+
+**Status:** Entschieden (2026-04-22)
+**Beteiligte:** Entwickler (KN)
+
+## Kontext
+
+Der Olivalle-Webshop läuft live auf fly.io. Die SQLite-DB
+(`/data/olivalle.db`, WAL-Modus) liegt auf einem persistenten fly-Volume.
+fly macht automatisch Volume-Snapshots, aber:
+- nur 5 Tage Retention
+- Snapshots einer WAL-SQLite können inkonsistent sein
+- kein dokumentierter Restore-Prozess, nie getestet
+
+Bei Volume-Verlust oder Korruption sind alle Bestellungen, Kundendaten
+und Rabattcodes weg. Nicht akzeptabel für einen Live-Shop.
+
+## Evaluierte Optionen
+
+| Option | Methode | Ziel-Storage | RPO | Kosten |
+|---|---|---|---|---|
+| (a) Litestream + Tigris | Kontinuierliche WAL-Replikation | Tigris (fly, cdg) | Sekunden | 0 CHF (Free Tier) |
+| (b) Täglicher sqlite3 .backup + Upload | Cron + Shell-Skript | Cloudflare R2 | 24h | 0 CHF |
+| (c) GitHub Action via fly ssh | Scheduled extern | Cloudflare R2 | 24h | 0 CHF |
+| (d) Nur fly-Snapshots (Status quo) | — | fly intern | Tage | 0 CHF |
+
+## Entscheidung
+
+**(a) Litestream mit Tigris-Bucket in Region `cdg` (Paris, EU).**
+
+### Entscheidungsfindung
+
+1. **RPO in Sekunden statt Tagen:** Jede Olivalle-Bestellung ist CHF 8–50.
+   Tagesverlust = reale Umsatzeinbussen + Vertrauensschaden. Litestream
+   repliziert praktisch verlustfrei.
+2. **DSG-konform:** Tigris-Region `cdg` = Paris/EU. Konsistent mit dem
+   Brevo-ADR (Frankreich).
+3. **Gratis bei dieser Grösse:** DB ~10 MB, Tigris Free Tier 10 GB.
+4. **Integriert in fly-Ökosystem:** Ein Account, ein Billing, ein CLI.
+5. **Automatischer Restore beim Container-Start:** Im Katastrophenfall
+   zieht `entrypoint.sh` den Backup automatisch — kein manueller Eingriff.
+
+### Verworfene Alternativen
+
+- **(b)/(c)** RPO zu hoch für Live-Shop mit echten Zahlungen
+- **(d)** 5-Tage-Retention und WAL-Inkonsistenz sind genau die Risiken,
+  die Issue #110 adressieren will
+
+## Konsequenzen
+
+- Neue Dateien: `Dockerfile` erweitert, `litestream.yml`, `entrypoint.sh`
+- Neue fly-Secrets: `LITESTREAM_ACCESS_KEY_ID`, `LITESTREAM_SECRET_ACCESS_KEY`,
+  `HEALTHCHECKS_URL` (manuell via `fly secrets set`, konsistent zur
+  Projekt-Konvention)
+- Neues Runbook: `docs/runbook-restore.md`
+- Monitoring: Healthchecks.io-Heartbeat alle 10 Min
+- Jährlicher manueller Restore-Test (Kalendereintrag)
+
+### Risiken & Folge-Issues
+
+- **Tigris-Ausfall bei gleichzeitigem fly-Ausfall**: Same-Provider-Risiko
+  bewusst akzeptiert. Migration nach Cloudflare R2 wäre nur eine
+  `litestream.yml`-Änderung, keine App-Änderung.
+- **Key-Rotation**: Tigris-Keys haben kein Ablaufdatum. Bei Entwickler-
+  Wechsel manuell rotieren und Runbook aktualisieren.

--- a/docs/adr-backup-strategie.md
+++ b/docs/adr-backup-strategie.md
@@ -19,21 +19,22 @@ und Rabattcodes weg. Nicht akzeptabel für einen Live-Shop.
 
 | Option | Methode | Ziel-Storage | RPO | Kosten |
 |---|---|---|---|---|
-| (a) Litestream + Tigris | Kontinuierliche WAL-Replikation | Tigris (fly, cdg) | Sekunden | 0 CHF (Free Tier) |
+| (a) Litestream + Tigris | Kontinuierliche WAL-Replikation | Tigris (fly, EU-Multi-Region) | Sekunden | 0 CHF (Free Tier) |
 | (b) Täglicher sqlite3 .backup + Upload | Cron + Shell-Skript | Cloudflare R2 | 24h | 0 CHF |
 | (c) GitHub Action via fly ssh | Scheduled extern | Cloudflare R2 | 24h | 0 CHF |
 | (d) Nur fly-Snapshots (Status quo) | — | fly intern | Tage | 0 CHF |
 
 ## Entscheidung
 
-**(a) Litestream mit Tigris-Bucket in Region `cdg` (Paris, EU).**
+**(a) Litestream mit Tigris-Bucket, Location `eur` (Multi-Region: Amsterdam + Frankfurt).**
 
 ### Entscheidungsfindung
 
 1. **RPO in Sekunden statt Tagen:** Jede Olivalle-Bestellung ist CHF 8–50.
    Tagesverlust = reale Umsatzeinbussen + Vertrauensschaden. Litestream
    repliziert praktisch verlustfrei.
-2. **DSG-konform:** Tigris-Region `cdg` = Paris/EU. Konsistent mit dem
+2. **DSG-konform:** Tigris-Location `eur` hält die Daten ausschliesslich in
+   der EU (Amsterdam + Frankfurt, zwei Kopien). Konsistent mit dem
    Brevo-ADR (Frankreich).
 3. **Gratis bei dieser Grösse:** DB ~10 MB, Tigris Free Tier 10 GB.
 4. **Integriert in fly-Ökosystem:** Ein Account, ein Billing, ein CLI.

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,6 +9,8 @@
 | [roadmap.md](roadmap.md) | Entwicklungsphasen mit Teilzielen und Meilensteinen |
 | [adr-domain-registrar.md](adr-domain-registrar.md) | ADR: Domain-Registrar-Wahl (Infomaniak) |
 | [adr-email-provider.md](adr-email-provider.md) | ADR: E-Mail-Provider-Wahl (Brevo) |
+| [adr-backup-strategie.md](adr-backup-strategie.md) | ADR: Backup-Strategie (Litestream + Tigris) |
+| [runbook-restore.md](runbook-restore.md) | Runbook: Backup-Restore (3 Szenarien) |
 | [security.md](security.md) | Sicherheits-Referenz |
 | [user-stories-testplan.md](user-stories-testplan.md) | User Stories & Testplan |
 | **Rechtliches** | |

--- a/docs/runbook-restore.md
+++ b/docs/runbook-restore.md
@@ -1,0 +1,149 @@
+# Runbook: Backup-Restore für Olivalle
+
+**Ziel-Leser:** Entwickler oder Inhaber. Szenario A kann der Inhaber
+eigenständig durchführen, falls fly-CLI-Zugang vorhanden.
+
+**Siehe auch:** [`adr-backup-strategie.md`](adr-backup-strategie.md)
+
+## Zugänge, die nötig sind
+
+| Was | Wo | Wer hat Zugriff |
+|---|---|---|
+| fly-Account (olivalle-App) | https://fly.io | Entwickler |
+| Tigris-Bucket `olivalle-backup` | `fly storage` | automatisch via fly-Secrets |
+| Healthchecks.io-Check | https://healthchecks.io | Entwickler |
+| Domain-Registrar (DNS) | siehe `adr-domain-registrar.md` | Entwickler |
+
+fly-Support im Ernstfall: https://community.fly.io oder
+https://fly.io/docs/about/support/.
+
+---
+
+## Szenario A — Komplettverlust des fly-Volumes
+
+**Symptom:** fly meldet Volume-Ausfall, die Machine startet nicht oder startet
+mit leerer DB.
+
+```bash
+fly logs -a olivalle                    # Ursache prüfen
+fly deploy                              # entrypoint.sh triggert Auto-Restore
+```
+
+`entrypoint.sh` erkennt beim Start, dass `/data/olivalle.db` fehlt, und zieht
+den letzten Stand aus Tigris. Erwartete Downtime ~5 Min, Datenverlust im
+Sekundenbereich.
+
+**Verifikation:**
+1. Shop-Startseite aufrufen → 200
+2. Im Admin-Bereich die letzten 5 Bestellungen gegen das Stripe-Dashboard
+   abgleichen
+
+---
+
+## Szenario B — DB ist da, aber korrupt
+
+**Symptom:** Admin-Bereich zeigt Unsinn, Fehler in `fly logs`, oder
+`PRAGMA integrity_check` schlägt fehl.
+
+```bash
+fly ssh console -a olivalle
+```
+
+Im Container:
+
+```sh
+# Alte DB wegsichern (nicht löschen — forensische Reserve)
+mv /data/olivalle.db /data/olivalle.db.broken
+
+# Restore aus Tigris (optional Point-in-Time)
+litestream restore -config /etc/litestream.yml /data/olivalle.db
+# Point-in-Time-Variante:
+# litestream restore -timestamp 2026-04-22T14:00:00Z \
+#   -config /etc/litestream.yml /data/olivalle.db
+
+exit
+```
+
+Danach:
+
+```bash
+fly machine restart -a olivalle
+```
+
+**Verifikation** wie Szenario A.
+
+---
+
+## Szenario C — Jährlicher Restore-Test
+
+**Kalendereintrag:** "Olivalle Backup-Test" — 1x/Jahr (empfohlen im April,
+zum Jahrestag der Einführung).
+
+### Schritte
+
+1. Tigris-Credentials lokal als ENV-Vars setzen (aus fly-Secrets):
+
+   ```bash
+   export LITESTREAM_ACCESS_KEY_ID="$(fly secrets list --app olivalle | grep LITESTREAM_ACCESS_KEY_ID)"  # Wert ist nicht sichtbar → temporär via 'fly ssh console' und echo holen ODER aus eigenem Passwort-Manager
+   export LITESTREAM_SECRET_ACCESS_KEY="…"
+   ```
+
+   > **Hinweis:** `fly secrets list` zeigt Secrets nicht im Klartext. Praktikabler
+   > Weg: `fly ssh console -a olivalle -C 'printenv LITESTREAM_ACCESS_KEY_ID'`
+   > (einmalig für den Test, danach lokal wieder löschen).
+
+2. Restore in ein tmp-File:
+
+   ```bash
+   litestream restore \
+     -config litestream.yml \
+     -o /tmp/olivalle-restore-test.db
+   ```
+
+3. Integritätscheck:
+
+   ```bash
+   sqlite3 /tmp/olivalle-restore-test.db "PRAGMA integrity_check;"
+   ```
+
+   Erwartet: `ok`.
+
+4. Plausibilitätsabfrage:
+
+   ```bash
+   sqlite3 /tmp/olivalle-restore-test.db \
+     "SELECT COUNT(*) AS bestellungen,
+             MIN(erstellt_am) AS erste,
+             MAX(erstellt_am) AS letzte
+      FROM bestellungen;"
+   ```
+
+   Die Anzahl muss plausibel zum Shop-Umsatz der letzten Monate passen.
+
+5. Ergebnis im Anhang unten festhalten und tmp-File löschen:
+
+   ```bash
+   rm /tmp/olivalle-restore-test.db
+   ```
+
+---
+
+## Heartbeat-Alert erhalten — was tun?
+
+Healthchecks.io mailt, wenn > 15 Min kein Ping kam.
+
+1. `fly logs -a olivalle` — läuft die App überhaupt? (Machine könnte schlafen)
+2. `fly ssh console -a olivalle` → `ls -la /data/olivalle.db-litestream`
+   → Modifikationszeiten prüfen
+3. `fly logs` nach `litestream:` filtern — Replikationsfehler sichtbar?
+4. Häufigster Fall: Tigris-Credentials rotiert/abgelaufen → neue Keys
+   erzeugen (`fly storage create` hat eine `regen`-Variante oder Bucket
+   neu anlegen) und via `fly secrets set` injizieren.
+
+---
+
+## Anhang: Protokoll der Restore-Tests
+
+| Datum | Ergebnis `integrity_check` | Bestellungen | Bemerkung |
+|---|---|---|---|
+| YYYY-MM-DD | ok / FAIL | N | — |

--- a/docs/superpowers/plans/2026-04-22-issue-110-sqlite-backup.md
+++ b/docs/superpowers/plans/2026-04-22-issue-110-sqlite-backup.md
@@ -1,0 +1,781 @@
+# SQLite-Backup-Strategie (Issue #110) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Kontinuierliche SQLite-Replikation via Litestream nach Tigris (Paris) einführen, mit Heartbeat-Monitoring, jährlichem Restore-Test-Runbook und automatischem Restore bei Volume-Verlust.
+
+**Architecture:** Litestream läuft als Sidecar im bestehenden fly-Container (PID 1, `-exec uvicorn`). Replikation nach Tigris-Bucket in Region `cdg`. Healthchecks.io-Heartbeat alle 10 Min aus `entrypoint.sh`-Loop. ADR + Runbook ergänzen bestehende `docs/`-Struktur.
+
+**Tech Stack:** Litestream 0.3.13, Tigris (fly storage), Healthchecks.io, Bash, pytest, shellcheck. Keine Python-Codeänderung (ausser einem Regressionstest).
+
+**Spec:** [`docs/superpowers/specs/2026-04-22-issue-110-sqlite-backup-design.md`](../specs/2026-04-22-issue-110-sqlite-backup-design.md)
+
+---
+
+## File Structure
+
+| Datei | Aktion | Verantwortung |
+|---|---|---|
+| `litestream.yml` | neu | Litestream-Replikationskonfig (eine DB, ein S3-Replica) |
+| `entrypoint.sh` | neu | Auto-Restore + Heartbeat-Loop + `litestream replicate -exec uvicorn` |
+| `Dockerfile` | modify | Litestream-Binary installieren, CMD → ENTRYPOINT |
+| `.dockerignore` | check | Sicherstellen, dass `litestream.yml`/`entrypoint.sh` nicht ausgeschlossen werden |
+| `tests/test_database_wal_mode.py` | neu | pytest: `get_db()` setzt `journal_mode=WAL` |
+| `docs/adr-backup-strategie.md` | neu | Architekturentscheidung (Format wie `adr-email-provider.md`) |
+| `docs/runbook-restore.md` | neu | Drei Restore-Szenarien (Volume-Verlust / Korruption / jährl. Test) |
+| `docs/index.md` | modify | Link auf ADR und Runbook ergänzen |
+| `README.md` | modify | Kurzer Backup-Abschnitt mit Link ins Runbook |
+| `Makefile` | modify | `shellcheck`-Target und Einbindung in `lint-all` |
+| `.github/workflows/lint.yml` | modify | shellcheck-Schritt ergänzen |
+
+**Secrets (einmalig manuell via CLI, nicht im Repo):**
+- `LITESTREAM_ACCESS_KEY_ID` (Tigris)
+- `LITESTREAM_SECRET_ACCESS_KEY` (Tigris)
+- `HEALTHCHECKS_URL` (Heartbeat-URL)
+
+---
+
+## Task 1: WAL-Modus-Regressionstest (pytest)
+
+**Files:**
+- Create: `tests/test_database_wal_mode.py`
+
+- [ ] **Step 1: Failing Test schreiben**
+
+```python
+# tests/test_database_wal_mode.py
+"""Regressionsschutz: get_db() muss WAL-Modus aktivieren.
+
+Litestream repliziert über das SQLite-WAL. Fällt der WAL-Modus aus,
+funktioniert das Backup stillschweigend nicht mehr.
+"""
+
+import sqlite3
+from pathlib import Path
+
+
+def test_get_db_aktiviert_wal_modus(monkeypatch, tmp_path):
+    db_path = tmp_path / "olivalle-test.db"
+    monkeypatch.setattr("app.config.settings.database_path", str(db_path))
+
+    from app.database import get_db
+
+    conn = get_db()
+    try:
+        row = conn.execute("PRAGMA journal_mode").fetchone()
+        assert row[0].lower() == "wal", (
+            f"journal_mode ist {row[0]}, erwartet 'wal' — "
+            "ohne WAL funktioniert die Litestream-Replikation nicht"
+        )
+    finally:
+        conn.close()
+```
+
+- [ ] **Step 2: Test ausführen und Fehler erwarten (falls Config nicht geladen)**
+
+Run: `uv run pytest tests/test_database_wal_mode.py -v`
+Expected: PASS — `get_db()` setzt WAL bereits in `app/database.py:12`. Dieser Test ist Regressionsschutz und soll sofort grün sein. Falls er rot ist: `app/database.py` wurde gebrochen und muss korrigiert werden, **bevor** der Rest des Plans weiterläuft.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_database_wal_mode.py
+git commit -m "test: WAL-Modus-Regressionsschutz fuer Litestream (#110)"
+```
+
+---
+
+## Task 2: `litestream.yml` anlegen
+
+**Files:**
+- Create: `litestream.yml` (Repo-Root)
+
+- [ ] **Step 1: Datei schreiben**
+
+```yaml
+# litestream.yml
+# Repliziert /data/olivalle.db kontinuierlich nach Tigris (Paris / cdg).
+# Secrets (LITESTREAM_*) werden via fly secrets set injiziert.
+dbs:
+  - path: /data/olivalle.db
+    replicas:
+      - type: s3
+        bucket: olivalle-backup
+        path: olivalle
+        region: auto
+        endpoint: https://fly.storage.tigris.dev
+        access-key-id: ${LITESTREAM_ACCESS_KEY_ID}
+        secret-access-key: ${LITESTREAM_SECRET_ACCESS_KEY}
+        retention: 720h              # 30 Tage
+        retention-check-interval: 24h
+        snapshot-interval: 24h
+        sync-interval: 1s
+```
+
+- [ ] **Step 2: Verifizieren dass `.dockerignore` die Datei nicht ausschliesst**
+
+Run: `grep -n litestream .dockerignore || echo "nicht ignoriert → ok"`
+Expected: Ausgabe `nicht ignoriert → ok`. Falls Ausgabe eine Zeile mit Pattern zeigt → Eintrag entfernen, weil die Datei ins Image muss.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add litestream.yml
+git commit -m "feat: Litestream-Konfig fuer Tigris-Replikation (#110)"
+```
+
+---
+
+## Task 3: `entrypoint.sh` anlegen + shellcheck lokal prüfen
+
+**Files:**
+- Create: `entrypoint.sh` (Repo-Root)
+
+- [ ] **Step 1: Script schreiben**
+
+```bash
+#!/bin/sh
+# entrypoint.sh
+# Startet Litestream (PID 1) + uvicorn. Restored bei leerem Volume automatisch
+# und pingt Healthchecks.io periodisch, solange Litestream repliziert.
+set -eu
+
+DB_PATH="${DATABASE_PATH:-/data/olivalle.db}"
+STATE_DIR="${DB_PATH}-litestream"
+HEARTBEAT_URL="${HEALTHCHECKS_URL:-}"
+
+# 1) Auto-Restore bei leerem Volume
+if [ ! -f "$DB_PATH" ]; then
+  echo "[entrypoint] Keine DB gefunden — versuche Restore aus Tigris…"
+  litestream restore -if-replica-exists -config /etc/litestream.yml "$DB_PATH" || {
+    echo "[entrypoint] Kein Backup vorhanden (erstes Deployment) — frische DB."
+  }
+fi
+
+# 2) Migrationen (idempotent, auf Volume)
+python -c 'from app.database import init_db; init_db()'
+
+# 3) Heartbeat-Loop im Hintergrund
+if [ -n "$HEARTBEAT_URL" ]; then
+  (
+    while true; do
+      sleep 600
+      if find "$STATE_DIR" -type f -mmin -15 2>/dev/null | grep -q .; then
+        curl -fsS -m 10 --retry 3 -o /dev/null "$HEARTBEAT_URL" || true
+      fi
+    done
+  ) &
+fi
+
+# 4) Litestream als PID 1, uvicorn als ueberwachter Subprocess
+exec litestream replicate -config /etc/litestream.yml -exec \
+  "uvicorn app.main:app --host 0.0.0.0 --port 8000 --proxy-headers --forwarded-allow-ips=*"
+```
+
+Run:
+```bash
+chmod +x entrypoint.sh
+```
+
+- [ ] **Step 2: shellcheck lokal installieren (falls fehlend) und ausführen**
+
+Run: `command -v shellcheck >/dev/null || brew install shellcheck`
+Run: `shellcheck entrypoint.sh`
+Expected: keine Warnungen (exit 0). Falls Warnungen: korrigieren, bevor weiter.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add entrypoint.sh
+git commit -m "feat: entrypoint.sh mit Litestream-Auto-Restore + Heartbeat (#110)"
+```
+
+---
+
+## Task 4: Dockerfile anpassen
+
+**Files:**
+- Modify: `Dockerfile:22-31` (EXPOSE + CMD-Block ersetzen)
+
+- [ ] **Step 1: Dockerfile editieren**
+
+Ersetze den Block ab `EXPOSE 8000` (aktuell `Dockerfile:22-31`) durch:
+
+```dockerfile
+# Litestream-Binary installieren (pinned, analog zum SHA-Pinning-Grundsatz).
+# Architektur via TARGETARCH damit fly sowohl amd64 als auch arm64 deployen kann.
+ARG LITESTREAM_VERSION=0.3.13
+ARG TARGETARCH=amd64
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends curl ca-certificates \
+ && curl -fsSL "https://github.com/benbjohnson/litestream/releases/download/v${LITESTREAM_VERSION}/litestream-v${LITESTREAM_VERSION}-linux-${TARGETARCH}.tar.gz" \
+      | tar -xzC /usr/local/bin \
+ && apt-get purge -y curl \
+ && apt-get autoremove -y \
+ && rm -rf /var/lib/apt/lists/*
+
+COPY litestream.yml /etc/litestream.yml
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+EXPOSE 8000
+
+ARG APP_VERSION=dev
+ENV APP_VERSION=${APP_VERSION}
+
+# Migrationen + uvicorn werden von entrypoint.sh orchestriert.
+ENTRYPOINT ["/entrypoint.sh"]
+```
+
+Der alte `CMD`-Zeile wird komplett entfernt — Migration und uvicorn laufen nun aus `entrypoint.sh`.
+
+- [ ] **Step 2: Image lokal bauen, um Syntaxfehler auszuschliessen**
+
+Run: `docker build -t olivalle-litestream-check .`
+Expected: Build erfolgreich. Wichtig: `curl` muss in Stage 2 installiert sein (python:3.13-slim hat es nicht), deshalb der apt-Block.
+
+- [ ] **Step 3: Litestream im Image prüfen**
+
+Run: `docker run --rm --entrypoint litestream olivalle-litestream-check version`
+Expected: Ausgabe `v0.3.13`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Dockerfile
+git commit -m "feat: Dockerfile installiert Litestream und nutzt entrypoint.sh (#110)"
+```
+
+---
+
+## Task 5: ADR schreiben
+
+**Files:**
+- Create: `docs/adr-backup-strategie.md`
+
+- [ ] **Step 1: Datei schreiben** — Inhalt exakt wie folgt (Format orientiert sich an `docs/adr-email-provider.md`):
+
+```markdown
+# ADR: Backup-Strategie — Litestream + Tigris
+
+**Status:** Entschieden (2026-04-22)
+**Beteiligte:** Entwickler (KN)
+
+## Kontext
+
+Der Olivalle-Webshop läuft live auf fly.io. Die SQLite-DB
+(`/data/olivalle.db`, WAL-Modus) liegt auf einem persistenten fly-Volume.
+fly macht automatisch Volume-Snapshots, aber:
+- nur 5 Tage Retention
+- Snapshots einer WAL-SQLite können inkonsistent sein
+- kein dokumentierter Restore-Prozess, nie getestet
+
+Bei Volume-Verlust oder Korruption sind alle Bestellungen, Kundendaten
+und Rabattcodes weg. Nicht akzeptabel für einen Live-Shop.
+
+## Evaluierte Optionen
+
+| Option | Methode | Ziel-Storage | RPO | Kosten |
+|---|---|---|---|---|
+| (a) Litestream + Tigris | Kontinuierliche WAL-Replikation | Tigris (fly, cdg) | Sekunden | 0 CHF (Free Tier) |
+| (b) Täglicher sqlite3 .backup + Upload | Cron + Shell-Skript | Cloudflare R2 | 24h | 0 CHF |
+| (c) GitHub Action via fly ssh | Scheduled extern | Cloudflare R2 | 24h | 0 CHF |
+| (d) Nur fly-Snapshots (Status quo) | — | fly intern | Tage | 0 CHF |
+
+## Entscheidung
+
+**(a) Litestream mit Tigris-Bucket in Region `cdg` (Paris, EU).**
+
+### Entscheidungsfindung
+
+1. **RPO in Sekunden statt Tagen:** Jede Olivalle-Bestellung ist CHF 8–50.
+   Tagesverlust = reale Umsatzeinbussen + Vertrauensschaden. Litestream
+   repliziert praktisch verlustfrei.
+2. **DSG-konform:** Tigris-Region `cdg` = Paris/EU. Konsistent mit dem
+   Brevo-ADR (Frankreich).
+3. **Gratis bei dieser Grösse:** DB ~10 MB, Tigris Free Tier 10 GB.
+4. **Integriert in fly-Ökosystem:** Ein Account, ein Billing, ein CLI.
+5. **Automatischer Restore beim Container-Start:** Im Katastrophenfall
+   zieht `entrypoint.sh` den Backup automatisch — kein manueller Eingriff.
+
+### Verworfene Alternativen
+
+- **(b)/(c)** RPO zu hoch für Live-Shop mit echten Zahlungen
+- **(d)** 5-Tage-Retention und WAL-Inkonsistenz sind genau die Risiken,
+  die Issue #110 adressieren will
+
+## Konsequenzen
+
+- Neue Dateien: `Dockerfile` erweitert, `litestream.yml`, `entrypoint.sh`
+- Neue fly-Secrets: `LITESTREAM_ACCESS_KEY_ID`, `LITESTREAM_SECRET_ACCESS_KEY`,
+  `HEALTHCHECKS_URL` (manuell via `fly secrets set`, konsistent zur
+  Projekt-Konvention)
+- Neues Runbook: `docs/runbook-restore.md`
+- Monitoring: Healthchecks.io-Heartbeat alle 10 Min
+- Jährlicher manueller Restore-Test (Kalendereintrag)
+
+### Risiken & Folge-Issues
+
+- **Tigris-Ausfall bei gleichzeitigem fly-Ausfall**: Same-Provider-Risiko
+  bewusst akzeptiert. Migration nach Cloudflare R2 wäre nur eine
+  `litestream.yml`-Änderung, keine App-Änderung.
+- **Key-Rotation**: Tigris-Keys haben kein Ablaufdatum. Bei Entwickler-
+  Wechsel manuell rotieren und Runbook aktualisieren.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/adr-backup-strategie.md
+git commit -m "docs: ADR Backup-Strategie Litestream+Tigris (#110)"
+```
+
+---
+
+## Task 6: Runbook schreiben
+
+**Files:**
+- Create: `docs/runbook-restore.md`
+
+- [ ] **Step 1: Datei schreiben**
+
+````markdown
+# Runbook: Backup-Restore für Olivalle
+
+**Ziel-Leser:** Entwickler oder Inhaber. Szenario A kann der Inhaber
+eigenständig durchführen, falls fly-CLI-Zugang vorhanden.
+
+**Siehe auch:** [`adr-backup-strategie.md`](adr-backup-strategie.md)
+
+## Zugänge, die nötig sind
+
+| Was | Wo | Wer hat Zugriff |
+|---|---|---|
+| fly-Account (olivalle-App) | https://fly.io | Entwickler |
+| Tigris-Bucket `olivalle-backup` | `fly storage` | automatisch via fly-Secrets |
+| Healthchecks.io-Check | https://healthchecks.io | Entwickler |
+| Domain-Registrar (DNS) | siehe `adr-domain-registrar.md` | Entwickler |
+
+fly-Support im Ernstfall: https://community.fly.io oder
+https://fly.io/docs/about/support/.
+
+---
+
+## Szenario A — Komplettverlust des fly-Volumes
+
+**Symptom:** fly meldet Volume-Ausfall, die Machine startet nicht oder startet
+mit leerer DB.
+
+```bash
+fly logs -a olivalle                    # Ursache prüfen
+fly deploy                              # entrypoint.sh triggert Auto-Restore
+```
+
+`entrypoint.sh` erkennt beim Start, dass `/data/olivalle.db` fehlt, und zieht
+den letzten Stand aus Tigris. Erwartete Downtime ~5 Min, Datenverlust im
+Sekundenbereich.
+
+**Verifikation:**
+1. Shop-Startseite aufrufen → 200
+2. Im Admin-Bereich die letzten 5 Bestellungen gegen das Stripe-Dashboard
+   abgleichen
+
+---
+
+## Szenario B — DB ist da, aber korrupt
+
+**Symptom:** Admin-Bereich zeigt Unsinn, Fehler in `fly logs`, oder
+`PRAGMA integrity_check` schlägt fehl.
+
+```bash
+fly ssh console -a olivalle
+```
+
+Im Container:
+
+```sh
+# Alte DB wegsichern (nicht löschen — forensische Reserve)
+mv /data/olivalle.db /data/olivalle.db.broken
+
+# Restore aus Tigris (optional Point-in-Time)
+litestream restore -config /etc/litestream.yml /data/olivalle.db
+# Point-in-Time-Variante:
+# litestream restore -timestamp 2026-04-22T14:00:00Z \
+#   -config /etc/litestream.yml /data/olivalle.db
+
+exit
+```
+
+Danach:
+
+```bash
+fly machine restart -a olivalle
+```
+
+**Verifikation** wie Szenario A.
+
+---
+
+## Szenario C — Jährlicher Restore-Test
+
+**Kalendereintrag:** "Olivalle Backup-Test" — 1x/Jahr (empfohlen im April,
+zum Jahrestag der Einführung).
+
+### Schritte
+
+1. Tigris-Credentials lokal als ENV-Vars setzen (aus fly-Secrets):
+
+   ```bash
+   export LITESTREAM_ACCESS_KEY_ID="$(fly secrets list --app olivalle | grep LITESTREAM_ACCESS_KEY_ID)"  # Wert ist nicht sichtbar → temporär via 'fly ssh console' und echo holen ODER aus eigenem Passwort-Manager
+   export LITESTREAM_SECRET_ACCESS_KEY="…"
+   ```
+
+   > **Hinweis:** `fly secrets list` zeigt Secrets nicht im Klartext. Praktikabler
+   > Weg: `fly ssh console -a olivalle -C 'printenv LITESTREAM_ACCESS_KEY_ID'`
+   > (einmalig für den Test, danach lokal wieder löschen).
+
+2. Restore in ein tmp-File:
+
+   ```bash
+   litestream restore \
+     -config litestream.yml \
+     -o /tmp/olivalle-restore-test.db
+   ```
+
+3. Integritätscheck:
+
+   ```bash
+   sqlite3 /tmp/olivalle-restore-test.db "PRAGMA integrity_check;"
+   ```
+
+   Erwartet: `ok`.
+
+4. Plausibilitätsabfrage:
+
+   ```bash
+   sqlite3 /tmp/olivalle-restore-test.db \
+     "SELECT COUNT(*) AS bestellungen,
+             MIN(erstellt_am) AS erste,
+             MAX(erstellt_am) AS letzte
+      FROM bestellungen;"
+   ```
+
+   Die Anzahl muss plausibel zum Shop-Umsatz der letzten Monate passen.
+
+5. Ergebnis im Anhang unten festhalten und tmp-File löschen:
+
+   ```bash
+   rm /tmp/olivalle-restore-test.db
+   ```
+
+---
+
+## Heartbeat-Alert erhalten — was tun?
+
+Healthchecks.io mailt, wenn > 15 Min kein Ping kam.
+
+1. `fly logs -a olivalle` — läuft die App überhaupt? (Machine könnte schlafen)
+2. `fly ssh console -a olivalle` → `ls -la /data/olivalle.db-litestream`
+   → Modifikationszeiten prüfen
+3. `fly logs` nach `litestream:` filtern — Replikationsfehler sichtbar?
+4. Häufigster Fall: Tigris-Credentials rotiert/abgelaufen → neue Keys
+   erzeugen (`fly storage create` hat eine `regen`-Variante oder Bucket
+   neu anlegen) und via `fly secrets set` injizieren.
+
+---
+
+## Anhang: Protokoll der Restore-Tests
+
+| Datum | Ergebnis `integrity_check` | Bestellungen | Bemerkung |
+|---|---|---|---|
+| YYYY-MM-DD | ok / FAIL | N | — |
+````
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/runbook-restore.md
+git commit -m "docs: Runbook fuer Backup-Restore (3 Szenarien + Heartbeat) (#110)"
+```
+
+---
+
+## Task 7: `docs/index.md` und `README.md` ergänzen
+
+**Files:**
+- Modify: `docs/index.md` (Link in bestehende Struktur einhängen)
+- Modify: `README.md` (Backup-Abschnitt)
+
+- [ ] **Step 1: `docs/index.md` prüfen und ergänzen**
+
+Run: `cat docs/index.md`
+Lokalisiere die ADR-Liste. Füge einen Eintrag ein:
+
+```markdown
+- [ADR: Backup-Strategie (Litestream + Tigris)](adr-backup-strategie.md)
+```
+
+Lokalisiere die Runbook-/Betriebsliste (oder schaffe sie, falls noch nicht existent). Füge ein:
+
+```markdown
+- [Runbook: Backup-Restore](runbook-restore.md)
+```
+
+- [ ] **Step 2: `README.md` ergänzen**
+
+Lokalisiere einen passenden Abschnitt (nach `Tech-Stack` oder vor `Schnellstart`). Füge ein:
+
+```markdown
+## Backups & Wiederherstellung
+
+Die SQLite-DB wird kontinuierlich via [Litestream](https://litestream.io)
+nach einem Tigris-Bucket (Region Paris) repliziert. Im Katastrophenfall
+(Volume-Verlust) restored der Container automatisch beim Start.
+
+- Architekturentscheidung: [`docs/adr-backup-strategie.md`](docs/adr-backup-strategie.md)
+- Restore-Anleitung: [`docs/runbook-restore.md`](docs/runbook-restore.md)
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/index.md README.md
+git commit -m "docs: Backup-Strategie in README und Doku-Index verlinken (#110)"
+```
+
+---
+
+## Task 8: shellcheck in Makefile und CI integrieren
+
+**Files:**
+- Modify: `Makefile` (neuer Target + `lint-all` erweitern)
+- Modify: `.github/workflows/lint.yml` (shellcheck-Step ergänzen)
+
+- [ ] **Step 1: Makefile anpassen**
+
+Bearbeite `Makefile`. In der `.PHONY:`-Zeile `shellcheck` ergänzen:
+
+```makefile
+.PHONY: help dev test lint lint-all format migrate docs css-build css-watch shellcheck
+```
+
+Am Ende neuen Target ergänzen:
+
+```makefile
+shellcheck: ## Shell-Skripte statisch prüfen
+	shellcheck entrypoint.sh
+```
+
+`lint-all`-Target um shellcheck erweitern:
+
+```makefile
+lint-all: ## Ruff-Check + Format-Check + shellcheck (gleich wie CI)
+	uv run ruff check app tests
+	uv run ruff format --check app tests
+	shellcheck entrypoint.sh
+```
+
+- [ ] **Step 2: Lokal prüfen**
+
+Run: `make lint-all`
+Expected: keine Fehler. Falls `shellcheck` fehlt: `brew install shellcheck`.
+
+- [ ] **Step 3: CI-Workflow anpassen**
+
+Bearbeite `.github/workflows/lint.yml`. Nach dem Ruff-Format-Step ergänzen:
+
+```yaml
+      - name: ShellCheck
+        uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38  # v2.0.0
+        with:
+          scandir: '.'
+          additional_files: 'entrypoint.sh'
+```
+
+> SHA-Pinning ist Projektstandard (Memory `feedback_github_actions_sha_pinning.md`).
+> Der SHA oben ist `ludeeus/action-shellcheck@v2.0.0`. **Vor Commit verifizieren**
+> mit: `gh api repos/ludeeus/action-shellcheck/git/refs/tags/v2.0.0 --jq .object.sha`
+> (falls ein neuerer v2-Tag existiert, dessen SHA verwenden).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Makefile .github/workflows/lint.yml
+git commit -m "ci: shellcheck fuer entrypoint.sh in make lint-all + CI (#110)"
+```
+
+---
+
+## Task 9: Tigris-Bucket + fly-Secrets setzen (manuelle Vorarbeit vor Deploy)
+
+> **Diese Task produziert keinen Repo-Commit** — sie dokumentiert die manuellen Schritte, die **einmalig** vor dem Merge-Deploy ausgeführt werden. Resultat dieser Task: drei gesetzte fly-Secrets und ein aktiver Healthchecks.io-Check.
+
+- [ ] **Step 1: Tigris-Bucket anlegen**
+
+Run:
+```bash
+fly storage create olivalle-backup --org personal
+```
+
+Expected: Ausgabe mit `BUCKET_NAME`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`. Den Bucket-Namen im Kopf behalten (soll `olivalle-backup` sein; falls fly einen Suffix vergibt → `litestream.yml` entsprechend anpassen und Commit vor Deploy).
+
+- [ ] **Step 2: Region prüfen**
+
+Run: `fly storage list`
+Expected: Bucket in Region `cdg` (Paris). Falls andere Region → Bucket löschen und neu anlegen mit `--region cdg`.
+
+- [ ] **Step 3: Healthchecks.io-Check anlegen**
+
+1. Auf https://healthchecks.io anmelden (Free Tier, 20 Checks)
+2. Neuen Check "olivalle-litestream-heartbeat" anlegen
+3. Period: 10 Minuten, Grace: 5 Minuten (= Alarm nach 15 Min ohne Ping)
+4. Benachrichtigung auf `konstantin.niedermann@gmail.com` konfigurieren
+5. Ping-URL kopieren (Format: `https://hc-ping.com/<uuid>`)
+
+- [ ] **Step 4: fly-Secrets setzen (LITESTREAM_*-Namespace)**
+
+> `fly storage create` setzt die Werte standardmässig als `AWS_ACCESS_KEY_ID` und
+> `AWS_SECRET_ACCESS_KEY` auf der App. Wir spiegeln sie bewusst unter
+> `LITESTREAM_*`, damit der Zweck im Namen sichtbar ist und keine Kollision mit
+> zukünftigen AWS-SDK-Usages entsteht.
+
+Run:
+```bash
+# 1) Werte (aus Schritt 1 Output) unter LITESTREAM_* setzen
+fly secrets set \
+  LITESTREAM_ACCESS_KEY_ID='<aus Schritt 1>' \
+  LITESTREAM_SECRET_ACCESS_KEY='<aus Schritt 1>' \
+  HEALTHCHECKS_URL='<aus Schritt 3>' \
+  --app olivalle
+
+# 2) Die redundanten AWS_*-Secrets entfernen (nicht nötig, da litestream.yml
+#    explizit LITESTREAM_* referenziert)
+fly secrets unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY --app olivalle
+```
+
+Expected: `Secrets are staged for the first deployment`.
+
+- [ ] **Step 5: Secrets verifizieren**
+
+Run: `fly secrets list --app olivalle`
+Expected: `LITESTREAM_ACCESS_KEY_ID`, `LITESTREAM_SECRET_ACCESS_KEY`, `HEALTHCHECKS_URL`, `BUCKET_NAME` sichtbar. Kein `AWS_*` mehr (falls doch: Unset nochmal ausführen).
+
+- [ ] **Step 6: Bucket-Namen in `litestream.yml` gegenprüfen**
+
+`fly storage create` kann den Bucket-Namen mit einem Org-Prefix versehen. Prüfen:
+
+Run: `fly secrets list --app olivalle | grep BUCKET_NAME`
+Wenn der echte Bucket-Name **nicht** `olivalle-backup` ist: `litestream.yml` anpassen:
+
+```yaml
+bucket: <tatsächlicher Bucket-Name aus fly secrets>
+```
+
+und einen zusätzlichen Commit auf dem Feature-Branch machen, bevor Task 10 ausgeführt wird:
+
+```bash
+git add litestream.yml
+git commit -m "fix: Bucket-Namen an tatsaechlichen Tigris-Namen anpassen (#110)"
+```
+
+---
+
+## Task 10: Deploy + Abnahme-Checkliste
+
+> **Erst ausführen, nachdem Tasks 1–9 gemerged oder in einem gemeinsamen PR gebündelt sind und Task 9 (manuell) erledigt ist.**
+
+- [ ] **Step 1: CI lokal spiegeln**
+
+Run: `make lint-all && uv run pytest -q`
+Expected: alles grün.
+
+- [ ] **Step 2: Deployen**
+
+Run: `fly deploy --app olivalle`
+Expected: Build erfolgreich, Machine startet, `fly logs` zeigt nacheinander:
+1. `[entrypoint] Keine DB gefunden — versuche Restore aus Tigris…` (beim allerersten Deploy existiert kein Backup → "Kein Backup vorhanden — frische DB.") **ODER** bei jedem weiteren Deploy: DB existiert, Schritt wird übersprungen.
+2. Migration-Log aus `init_db()`
+3. `litestream: initialized db: /data/olivalle.db`
+4. `litestream: snapshot written` (innerhalb 2 Min)
+5. uvicorn Startup-Log
+
+- [ ] **Step 3: Tigris-Bucket-Inhalt prüfen**
+
+Run: `fly storage dashboard --app olivalle` (öffnet Browser) oder via AWS-CLI:
+
+```bash
+AWS_ACCESS_KEY_ID=<tigris-key> \
+AWS_SECRET_ACCESS_KEY=<tigris-secret> \
+aws s3 ls s3://olivalle-backup/olivalle/ \
+  --endpoint-url https://fly.storage.tigris.dev
+```
+
+Expected: Es erscheinen Pfade wie `generations/.../snapshots/` und `generations/.../wal/`.
+
+- [ ] **Step 4: Healthchecks.io-Status prüfen**
+
+Auf https://healthchecks.io → Check "olivalle-litestream-heartbeat" muss innerhalb 15 Min nach Deploy auf grün (`up`) gehen.
+
+- [ ] **Step 5: Katastrophenfall simulieren (einmaliger Restore-Test)**
+
+```bash
+fly ssh console -a olivalle
+# Im Container:
+mv /data/olivalle.db /data/olivalle.db.sim-backup
+exit
+fly machine restart -a olivalle
+```
+
+Nach ~30 Sek `fly logs`: muss `[entrypoint] Keine DB gefunden — versuche Restore aus Tigris…` und danach erfolgreichen Start zeigen. Shop-Startseite aufrufen, letzte 5 Bestellungen im Admin-Bereich prüfen → müssen vollständig sein.
+
+Aufräumen:
+```bash
+fly ssh console -a olivalle
+rm /data/olivalle.db.sim-backup
+exit
+```
+
+- [ ] **Step 6: Ergebnis in Runbook eintragen**
+
+Tabelle am Ende von `docs/runbook-restore.md` um eine Zeile erweitern:
+
+```markdown
+| 2026-04-22 | ok | <Anzahl aus Plausibilitätsabfrage> | Initialer Restore-Test |
+```
+
+```bash
+git add docs/runbook-restore.md
+git commit -m "docs: initialen Restore-Test im Runbook dokumentieren (#110)"
+git push
+```
+
+- [ ] **Step 7: Kalendereintrag erstellen**
+
+Google Calendar (oder äquivalent): "Olivalle Backup-Restore-Test" — 2027-04-22, ganztägig, jährlich wiederkehrend. Link ins Runbook in die Beschreibung.
+
+- [ ] **Step 8: Issue #110 schliessen**
+
+```bash
+gh issue close 110 --comment "Umgesetzt. ADR: docs/adr-backup-strategie.md, Runbook: docs/runbook-restore.md. Restore-Test erfolgreich durchgeführt 2026-04-22."
+```
+
+- [ ] **Step 9: Folge-Issues prüfen**
+
+Nach den Projekt-Regeln (Memory `feedback_pause_cleanup.md`): prüfen ob #111 (Uptime-Monitoring) jetzt einfacher wird, weil Healthchecks.io-Account bereits existiert. Falls ja: Hinweis im Issue #111 hinterlegen.
+
+---
+
+## Zusammenfassung der zu committenden Dateien
+
+| Datei | Commits |
+|---|---|
+| `tests/test_database_wal_mode.py` | Task 1 |
+| `litestream.yml` | Task 2 |
+| `entrypoint.sh` | Task 3 |
+| `Dockerfile` | Task 4 |
+| `docs/adr-backup-strategie.md` | Task 5 |
+| `docs/runbook-restore.md` | Task 6, Task 10/Step 6 |
+| `docs/index.md`, `README.md` | Task 7 |
+| `Makefile`, `.github/workflows/lint.yml` | Task 8 |
+
+Tasks 9 und 10 sind operativ, keine Repo-Änderungen ausser der Restore-Test-Zeile im Runbook.

--- a/docs/superpowers/specs/2026-04-22-issue-110-sqlite-backup-design.md
+++ b/docs/superpowers/specs/2026-04-22-issue-110-sqlite-backup-design.md
@@ -23,7 +23,7 @@ Ein Backup-System, das
 |---|---|
 | Backup-Methode | **Litestream** (kontinuierliche WAL-Replikation) |
 | Ziel-Storage | **Tigris** (fly-integriert, S3-kompatibel) |
-| Region | **`cdg`** (Paris, EU — DSG-konform, gleiche Region wie App) |
+| Location | **`eur`** (Multi-Region: Amsterdam + Frankfurt — DSG-konform, zwei Kopien in der EU) |
 | Retention | **30 Tage** (WAL + tägl. Snapshot) |
 | Heartbeat-Monitoring | **Healthchecks.io** (alle 10 Min) |
 | Restore-Test | **Jährlich manuell**, dokumentiert im Runbook |
@@ -46,16 +46,17 @@ Ein Backup-System, das
                     ┌────────────────┴────────┐
                     ▼                         ▼
           ┌──────────────────┐     ┌──────────────────┐
-          │ Tigris (cdg)     │     │ Healthchecks.io  │
-          │ s3://olivalle-   │     │ Heartbeat /10min │
-          │     backup/…     │     └──────────────────┘
+          │ Tigris (eur,     │     │ Healthchecks.io  │
+          │  ams+fra)        │     │ Heartbeat /10min │
+          │ s3://olivalle-   │     └──────────────────┘
+          │     backup/…     │
           └──────────────────┘
 ```
 
 **Komponenten:**
 1. **Litestream als Sidecar im gleichen Container** — PID 1, überwacht uvicorn als Child-Process
 2. **entrypoint.sh** — orchestriert Auto-Restore, startet Heartbeat-Loop, startet Litestream+uvicorn
-3. **Tigris-Bucket** in Region `cdg`, Credentials als fly-Secrets
+3. **Tigris-Bucket** mit Location `eur` (Multi-Region Amsterdam + Frankfurt), Credentials als fly-Secrets
 4. **Healthchecks.io-Heartbeat** — alle 10 Min, alarmiert per E-Mail bei Ausfall
 
 ## Dateien im Repo

--- a/docs/superpowers/specs/2026-04-22-issue-110-sqlite-backup-design.md
+++ b/docs/superpowers/specs/2026-04-22-issue-110-sqlite-backup-design.md
@@ -1,0 +1,205 @@
+# Design: SQLite-Backup-Strategie (Issue #110)
+
+**Datum:** 2026-04-22
+**Status:** Entwurf — Brainstorming abgeschlossen
+**Issue:** [#110](https://github.com/konstantinniedermann/olivalle-webshop/issues/110)
+
+## Kontext
+
+Der Olivalle-Webshop läuft live auf fly.io. Die SQLite-DB (`/data/olivalle.db`, WAL-Modus) liegt auf einem persistenten fly-Volume (`olivalle_data`). Aktuell existiert **kein dokumentierter Backup-Prozess**. fly.io macht automatisch Volume-Snapshots, aber nur mit 5 Tagen Retention und diese können bei WAL-aktiven SQLite-Dateien inkonsistent sein. Bei Volume-Verlust oder DB-Korruption sind alle Bestellungen, Kundendaten und Rabattcodes weg — nicht akzeptabel für einen Live-Shop mit echten Zahlungen.
+
+## Ziel
+
+Ein Backup-System, das
+- kontinuierlich repliziert (RPO in Sekunden),
+- DSG-konform in der EU liegt,
+- kostenlos bleibt (Projektvolumen ist winzig),
+- im Katastrophenfall automatisch wiederherstellt,
+- regelmässig überprüft wird (jährlicher manueller Restore-Test + automatischer Heartbeat-Alert).
+
+## Entscheidungen
+
+| Aspekt | Entscheidung |
+|---|---|
+| Backup-Methode | **Litestream** (kontinuierliche WAL-Replikation) |
+| Ziel-Storage | **Tigris** (fly-integriert, S3-kompatibel) |
+| Region | **`cdg`** (Paris, EU — DSG-konform, gleiche Region wie App) |
+| Retention | **30 Tage** (WAL + tägl. Snapshot) |
+| Heartbeat-Monitoring | **Healthchecks.io** (alle 10 Min) |
+| Restore-Test | **Jährlich manuell**, dokumentiert im Runbook |
+| Auto-Restore | **Ja** — entrypoint.sh restored bei leerem Volume automatisch |
+
+## Architektur
+
+```
+┌──────────────────────────────────────────────┐
+│   fly.io Machine (region cdg)                │
+│                                              │
+│   entrypoint.sh                              │
+│    ├─ litestream replicate (sidecar)         │
+│    │    └─ liest WAL aus olivalle.db         │
+│    └─ exec uvicorn app.main:app              │
+│                                              │
+│   /data/olivalle.db ──────WAL──────┐         │
+└────────────────────────────────────┼─────────┘
+                                     │
+                    ┌────────────────┴────────┐
+                    ▼                         ▼
+          ┌──────────────────┐     ┌──────────────────┐
+          │ Tigris (cdg)     │     │ Healthchecks.io  │
+          │ s3://olivalle-   │     │ Heartbeat /10min │
+          │     backup/…     │     └──────────────────┘
+          └──────────────────┘
+```
+
+**Komponenten:**
+1. **Litestream als Sidecar im gleichen Container** — PID 1, überwacht uvicorn als Child-Process
+2. **entrypoint.sh** — orchestriert Auto-Restore, startet Heartbeat-Loop, startet Litestream+uvicorn
+3. **Tigris-Bucket** in Region `cdg`, Credentials als fly-Secrets
+4. **Healthchecks.io-Heartbeat** — alle 10 Min, alarmiert per E-Mail bei Ausfall
+
+## Dateien im Repo
+
+| Datei | Status | Zweck |
+|---|---|---|
+| `Dockerfile` | erweitern | Litestream-Binary installieren, entrypoint.sh als CMD |
+| `entrypoint.sh` | neu | Auto-Restore + Heartbeat-Loop + Litestream+uvicorn-Start |
+| `litestream.yml` | neu | Replikationskonfig (Retention 30d, Snapshot 24h, Sync 1s) |
+| `docs/adr-backup-strategie.md` | neu | Architekturentscheidung dokumentiert |
+| `docs/runbook-restore.md` | neu | Drei Restore-Szenarien dokumentiert |
+| `tests/test_database_wal_mode.py` | neu | pytest: WAL-Modus-Regressionsschutz |
+| `README.md` | erweitern | Kurzer Hinweis auf Backup + Link ins Runbook |
+| `fly.toml` | unverändert | (Secrets werden via `fly secrets set` injiziert) |
+
+## Konfigurationen
+
+### `litestream.yml`
+
+```yaml
+dbs:
+  - path: /data/olivalle.db
+    replicas:
+      - type: s3
+        bucket: olivalle-backup
+        path: olivalle
+        region: auto
+        endpoint: https://fly.storage.tigris.dev
+        access-key-id: ${LITESTREAM_ACCESS_KEY_ID}
+        secret-access-key: ${LITESTREAM_SECRET_ACCESS_KEY}
+        retention: 720h
+        retention-check-interval: 24h
+        snapshot-interval: 24h
+        sync-interval: 1s
+```
+
+### `Dockerfile` (Ergänzung)
+
+```dockerfile
+ARG LITESTREAM_VERSION=0.3.13
+RUN curl -L https://github.com/benbjohnson/litestream/releases/download/v${LITESTREAM_VERSION}/litestream-v${LITESTREAM_VERSION}-linux-amd64.tar.gz \
+    | tar -xzC /usr/local/bin
+
+COPY litestream.yml /etc/litestream.yml
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]
+```
+
+Version `0.3.13` wird explizit gepinnt (gleiches Prinzip wie beim GitHub-Actions-SHA-Pinning).
+
+### `entrypoint.sh`
+
+```bash
+#!/bin/sh
+set -e
+
+# 1. Auto-Restore bei leerem Volume (Katastrophenfall)
+if [ ! -f /data/olivalle.db ]; then
+  echo "[entrypoint] Keine DB gefunden — versuche Restore aus Tigris…"
+  litestream restore -if-replica-exists -config /etc/litestream.yml /data/olivalle.db
+fi
+
+# 2. Heartbeat-Loop im Hintergrund
+#    (pingt Healthchecks.io nur wenn Litestream in letzten 15 Min geschrieben hat)
+(
+  while true; do
+    sleep 600
+    if find /data/olivalle.db-litestream -type f -mmin -15 2>/dev/null | grep -q .; then
+      curl -fsS -m 10 --retry 3 -o /dev/null "$HEALTHCHECKS_URL" || true
+    fi
+  done
+) &
+
+# 3. Litestream als PID 1, uvicorn als überwachter Subprocess
+exec litestream replicate -config /etc/litestream.yml -exec "uvicorn app.main:app --host 0.0.0.0 --port 8000"
+```
+
+### Neue fly-Secrets
+
+Einmalig manuell gesetzt (konsistent mit Memory `project_fly_secrets_approach.md`):
+
+```bash
+fly storage create olivalle-backup --org personal
+# gibt BUCKET_NAME, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY
+
+fly secrets set \
+  LITESTREAM_ACCESS_KEY_ID=... \
+  LITESTREAM_SECRET_ACCESS_KEY=... \
+  HEALTHCHECKS_URL=https://hc-ping.com/<uuid>
+```
+
+## Runbook-Szenarien
+
+Inhalt von `docs/runbook-restore.md`:
+
+**Szenario A — Komplettverlust des fly-Volumes**
+1. `fly logs -a olivalle` — Fehler prüfen
+2. `fly deploy` — entrypoint.sh triggert Auto-Restore
+3. Shop-Smoke-Test + Stripe-Abgleich der letzten Bestellungen
+
+Downtime ~5 Min, Datenverlust im Sekundenbereich.
+
+**Szenario B — Korrupte DB**
+1. `fly ssh console -a olivalle`
+2. `mv /data/olivalle.db /data/olivalle.db.broken`
+3. `litestream restore -config /etc/litestream.yml /data/olivalle.db` (optional `-timestamp`)
+4. `fly machine restart` — Smoke-Test
+
+**Szenario C — Jährlicher Restore-Test (geplant)**
+1. Lokal: `litestream restore -o /tmp/olivalle-restore-test.db -config litestream.yml`
+2. `sqlite3 /tmp/olivalle-restore-test.db "PRAGMA integrity_check;"` → `ok`
+3. `SELECT COUNT(*) FROM bestellungen` Plausibilitätscheck
+4. Datum und Ergebnis im Runbook-Anhang festhalten
+
+Runbook enthält ausserdem: Zugangsliste (fly, Tigris, Healthchecks.io), fly-Support-Kontakt, Links zur Litestream-Doku.
+
+## Testing & Abnahme
+
+**Ebene 1 — Automatisierte Tests (pytest + shellcheck, CI)**
+
+| Test | Prüft |
+|---|---|
+| `tests/test_database_wal_mode.py` | `PRAGMA journal_mode` liefert `wal` (Regressionsschutz) |
+| `shellcheck entrypoint.sh` | Statische Syntaxprüfung, eingehängt in `make lint-all` |
+
+**Ebene 2 — Manuelle Abnahme-Checkliste (im PR)**
+
+- **Pre-Deploy:** Tigris-Bucket angelegt, Secrets gesetzt, Healthchecks.io-Check aktiv
+- **Post-Deploy:** fly-logs zeigen `litestream: initialized db` und `snapshot written`, Tigris-Bucket enthält Snapshot, Healthchecks-Status `up`
+- **Restore-Test (einmalig):** Lokaler Restore + `integrity_check` + Plausibilitätsabfrage
+- **Katastrophenfall-Simulation:** `mv olivalle.db olivalle.db.bak`, Machine-Restart, Auto-Restore verifizieren
+
+## Risiken & bewusste Kompromisse
+
+- **Same-Provider-Risiko**: Backup bei fly (Tigris). Akzeptiert, weil Migration auf Cloudflare R2 später nur Litestream-Konfig-Änderung wäre, keine App-Änderung.
+- **Tigris-Keys beim Entwickler**: Für Restore braucht der Inhaber fly-CLI-Zugang oder Entwicklerhilfe. Akzeptiert für Einzelunternehmer-Projekt; weniger Credential-Standorte = weniger Angriffsfläche.
+- **Kein Staging-Restore-Workflow**: Jährlicher Test erfolgt lokal. Overhead einer Staging-Pipeline nicht gerechtfertigt für dieses Projektvolumen.
+
+## Issue-Abschlusskriterien
+
+- [ ] ADR, Runbook und Code-Änderungen gemerged (ein PR)
+- [ ] Alle Pre- und Post-Deploy-Checks abgehakt
+- [ ] Initialer Restore-Test dokumentiert
+- [ ] Kalendereintrag für jährlichen Restore-Test erstellt
+- [ ] Issue #110 geschlossen mit Link auf ADR

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+# entrypoint.sh
+# Startet Litestream (PID 1) + uvicorn. Restored bei leerem Volume automatisch
+# und pingt Healthchecks.io periodisch, solange Litestream repliziert.
+set -eu
+
+DB_PATH="${DATABASE_PATH:-/data/olivalle.db}"
+STATE_DIR="${DB_PATH}-litestream"
+HEARTBEAT_URL="${HEALTHCHECKS_URL:-}"
+
+# 1) Auto-Restore bei leerem Volume
+if [ ! -f "$DB_PATH" ]; then
+  echo "[entrypoint] Keine DB gefunden — versuche Restore aus Tigris…"
+  litestream restore -if-replica-exists -config /etc/litestream.yml "$DB_PATH" || {
+    echo "[entrypoint] Kein Backup vorhanden (erstes Deployment) — frische DB."
+  }
+fi
+
+# 2) Migrationen (idempotent, auf Volume)
+python -c 'from app.database import init_db; init_db()'
+
+# 3) Heartbeat-Loop im Hintergrund
+if [ -n "$HEARTBEAT_URL" ]; then
+  (
+    while true; do
+      sleep 600
+      if find "$STATE_DIR" -type f -mmin -15 2>/dev/null | grep -q .; then
+        curl -fsS -m 10 --retry 3 -o /dev/null "$HEARTBEAT_URL" || true
+      fi
+    done
+  ) &
+fi
+
+# 4) Litestream als PID 1, uvicorn als ueberwachter Subprocess
+exec litestream replicate -config /etc/litestream.yml -exec \
+  "uvicorn app.main:app --host 0.0.0.0 --port 8000 --proxy-headers --forwarded-allow-ips=*"

--- a/litestream.yml
+++ b/litestream.yml
@@ -1,0 +1,17 @@
+# litestream.yml
+# Repliziert /data/olivalle.db kontinuierlich nach Tigris (Paris / cdg).
+# Secrets (LITESTREAM_*) werden via fly secrets set injiziert.
+dbs:
+  - path: /data/olivalle.db
+    replicas:
+      - type: s3
+        bucket: olivalle-backup
+        path: olivalle
+        region: auto
+        endpoint: https://fly.storage.tigris.dev
+        access-key-id: ${LITESTREAM_ACCESS_KEY_ID}
+        secret-access-key: ${LITESTREAM_SECRET_ACCESS_KEY}
+        retention: 720h              # 30 Tage
+        retention-check-interval: 24h
+        snapshot-interval: 24h
+        sync-interval: 1s

--- a/tests/test_database_wal_mode.py
+++ b/tests/test_database_wal_mode.py
@@ -1,0 +1,22 @@
+"""Regressionsschutz: get_db() muss WAL-Modus aktivieren.
+
+Litestream repliziert über das SQLite-WAL. Fällt der WAL-Modus aus,
+funktioniert das Backup stillschweigend nicht mehr.
+"""
+
+
+def test_get_db_aktiviert_wal_modus(monkeypatch, tmp_path):
+    db_path = tmp_path / "olivalle-test.db"
+    monkeypatch.setattr("app.config.settings.database_path", str(db_path))
+
+    from app.database import get_db
+
+    conn = get_db()
+    try:
+        row = conn.execute("PRAGMA journal_mode").fetchone()
+        assert row[0].lower() == "wal", (
+            f"journal_mode ist {row[0]}, erwartet 'wal' — "
+            "ohne WAL funktioniert die Litestream-Replikation nicht"
+        )
+    finally:
+        conn.close()


### PR DESCRIPTION
## Summary

Implementiert kontinuierliche SQLite-Replikation nach Tigris (Paris) mit Auto-Restore, Healthchecks.io-Heartbeat und dokumentiertem Runbook. Closes #110 (nach erfolgreichem Deploy-Smoke-Test).

- **Spec:** [`docs/superpowers/specs/2026-04-22-issue-110-sqlite-backup-design.md`](docs/superpowers/specs/2026-04-22-issue-110-sqlite-backup-design.md)
- **Plan:** [`docs/superpowers/plans/2026-04-22-issue-110-sqlite-backup.md`](docs/superpowers/plans/2026-04-22-issue-110-sqlite-backup.md)

## Was der PR enthält (Tasks 1–8, alles im Code)

| Task | Commit | Datei(en) |
|---|---|---|
| 1 | `595f77f` | `tests/test_database_wal_mode.py` — Regressionsschutz für WAL |
| 2 | `d311e38` | `litestream.yml` — Replikationskonfig (30 Tage Retention, 1 s Sync) |
| 3 | `6bca5d6` | `entrypoint.sh` — Auto-Restore + Heartbeat-Loop + `litestream replicate -exec uvicorn` |
| 4 | `325432e` | `Dockerfile` — Litestream 0.3.13 installiert, `ENTRYPOINT` statt `CMD` |
| 5 | `5e23145` | `docs/adr-backup-strategie.md` |
| 6 | `008a4d0` | `docs/runbook-restore.md` — 3 Szenarien (Volume-Verlust / Korruption / jährlicher Test) + Heartbeat-Alert |
| 7 | `5eb571e` | `docs/index.md`, `README.md` — Verlinkung |
| 8 | `1bb7e19` | `Makefile`, `.github/workflows/lint.yml` — shellcheck in `lint-all` + CI (SHA-gepinnt) |

## Noch offen (operativ, wird nach Merge manuell vom Inhaber ausgeführt — Tasks 9 + 10 im Plan)

- [ ] Tigris-Bucket `olivalle-backup` via `fly storage create` anlegen (Region `cdg`)
- [ ] Healthchecks.io-Check "olivalle-litestream-heartbeat" anlegen (Period 10 min, Grace 5 min)
- [ ] fly-Secrets setzen: `LITESTREAM_ACCESS_KEY_ID`, `LITESTREAM_SECRET_ACCESS_KEY`, `HEALTHCHECKS_URL`
- [ ] `fly deploy` + Post-Deploy-Logs auf `litestream: snapshot written` prüfen
- [ ] Katastrophenfall simulieren (DB lokal wegschieben, Restart → Auto-Restore verifizieren)
- [ ] Restore-Test-Zeile in `docs/runbook-restore.md` ergänzen
- [ ] Kalendereintrag für jährlichen Restore-Test 2027-04-22

## Test plan

- [x] `uv run pytest -q` — 208 passed (+1 neu: `test_get_db_aktiviert_wal_modus`)
- [x] `uv run ruff check app tests` — passed
- [x] `uv run ruff format --check app tests` — passed
- [x] shellcheck via `koalaman/shellcheck:stable` auf `entrypoint.sh` — exit 0
- [x] `docker build -t olivalle-litestream-check .` — erfolgreich
- [x] `docker run --rm --entrypoint litestream olivalle-litestream-check version` → `v0.3.13`
- [ ] CI-Gate auf PR grün (wird durch diesen Push ausgelöst)
- [ ] Nach Merge: Tasks 9 + 10 aus dem Plan durchlaufen (operativ, nicht Teil dieses PRs)

## Risiken und bewusste Kompromisse

- **Same-Provider-Risiko** (Backup bei fly-Tigris): akzeptiert — Migration nach Cloudflare R2 wäre nur `litestream.yml`-Change.
- **Lokales `make lint-all`** scheitert, wenn shellcheck lokal nicht installiert ist; CI zieht es über die gepinnte Action. Docker-Fallback dokumentiert.
- **Dockerfile `TARGETARCH=amd64` als Default** — korrekt für fly.io-Prod (cdg = amd64). Apple-Silicon-Dev-Builds laufen via Rosetta/qemu, was für Build-Checks reicht.

🤖 Generated with [Claude Code](https://claude.com/claude-code)