### PR TITLE
feat: Externes Backup-Monitoring via GitHub Action (#118)

### DIFF
--- a/.github/workflows/backup-check.yml
+++ b/.github/workflows/backup-check.yml
@@ -1,0 +1,34 @@
+name: Backup-Monitoring
+
+on:
+  schedule:
+    - cron: '17 5 * * *'
+  workflow_dispatch:
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: Prüft Tigris-Backup-Frische
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
+        with:
+          python-version: "3.13"
+
+      - name: Install dependencies
+        run: uv sync --extra dev
+
+      - name: Check backup freshness
+        run: uv run python scripts/check_backup.py
+        env:
+          LITESTREAM_ACCESS_KEY_ID: ${{ secrets.LITESTREAM_ACCESS_KEY_ID }}
+          LITESTREAM_SECRET_ACCESS_KEY: ${{ secrets.LITESTREAM_SECRET_ACCESS_KEY }}
+          HEALTHCHECKS_URL: ${{ secrets.HEALTHCHECKS_URL }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,9 +19,9 @@ jobs:
       - name: Install dev dependencies
         run: uv sync --extra dev
       - name: Ruff Check
-        run: uv run ruff check app tests
+        run: uv run ruff check app tests scripts
       - name: Ruff Format Check
-        run: uv run ruff format --check app tests
+        run: uv run ruff format --check app tests scripts
       - name: ShellCheck
         uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38  # 2.0.0 (tag has no v-prefix)
         with:

--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ Entscheidungsgrundlagen siehe [`docs/arc42.md`](docs/arc42.md) und die ADRs unte
 Die SQLite-DB wird kontinuierlich via [Litestream](https://litestream.io)
 in einen Tigris-Bucket (EU-Multi-Region: Amsterdam + Frankfurt) repliziert.
 Im Katastrophenfall (Volume-Verlust) restored der Container automatisch
-beim Start.
+beim Start. Eine tägliche GitHub Action prüft die Backup-Frische gegen
+Healthchecks.io (Alarm bei Stillstand > 25 h).
 
 - Architekturentscheidung: [`docs/adr-backup-strategie.md`](docs/adr-backup-strategie.md)
 - Restore-Anleitung: [`docs/runbook-restore.md`](docs/runbook-restore.md)

--- a/docs/adr-backup-strategie.md
+++ b/docs/adr-backup-strategie.md
@@ -84,3 +84,26 @@ und Rabattcodes weg. Nicht akzeptabel für einen Live-Shop.
 - Ein Heartbeat-Alert ist ab 2026-04-22 **ernst zu nehmen** (keine Toleranz mehr durch Machine-Stop). Runbook-Abschnitt "Heartbeat-Alert erhalten" entsprechend aktualisiert.
 - Nebeneffekt: Kein Kaltstart-Delay (~3–10 s) für echte Kunden beim ersten Besuch nach Idle.
 - Verifikationsfenster: 7 Tage Beobachtung nach Deploy; Issue #116 schliesst erst dann.
+
+---
+
+## Nachtrag 2026-04-22b: Monitoring-Architektur-Umbau (Issue #118)
+
+**Kontext:** Nach Inbetriebnahme von #110 und #116 zeigten sich zwei Probleme am sekundären Heartbeat-Loop in `entrypoint.sh`:
+
+1. **Pfad-Bug:** Loop prüfte `/data/olivalle.db-litestream`, Litestream schreibt aber in `/data/.olivalle.db-litestream` (Dotfile) — kein einziger Ping seit #110 kam an.
+2. **Falsche Mess-Semantik:** Loop prüfte einen Zwischenschritt auf dem Server (lokale Litestream-Dateien), nicht das Ergebnis in der Cloud (Tigris-Replikat aktuell?).
+
+**Entscheidung:** Backup-Monitoring migriert in eine **scheduled GitHub Action** (`.github/workflows/backup-check.yml`, 1×/Tag), die via S3-API bei Tigris prüft, ob das neueste Objekt < 24 h alt ist. Bei OK → Ping an Healthchecks.io, sonst silent skip. Grace 25 h alarmiert per E-Mail.
+
+Damit wird das im #116-Nachtrag verworfene Argument ("Komplexität nicht lohnend für CHF 1.40/Mt Kostenersparnis") überholt — **nicht Kosten treiben den Wechsel, sondern Korrektheit**.
+
+**Konsequenzen:**
+- Heartbeat-Loop aus `entrypoint.sh` entfernt; Variablen `STATE_DIR` und `HEARTBEAT_URL` weg.
+- `HEALTHCHECKS_URL` wandert von fly-Secret nach GitHub Repo-Secret.
+- Healthchecks.io-Check `olivalle-litestream-heartbeat` umkonfiguriert: Period `10 min` → `1 day`, Grace `5 min` → `25 h`. Name + Ping-URL bleiben, Historie erhalten.
+- Credentials: bestehende `LITESTREAM_*`-Keys werden wiederverwendet (read-only im S3-ListObjectsV2-Kontext).
+
+**Tradeoff:** Bei Tigris-API-Ausfall `silent skip` statt `fail loud` — verhindert false-alarm-Mails bei kurzen Hickups, verzögert aber den Alarm bei mehrtägigem Tigris-Ausfall auf ~48 h. Für Olivalle-Scale akzeptabel.
+
+**Details:** [`docs/superpowers/specs/2026-04-22-issue-118-backup-monitoring-design.md`](superpowers/specs/2026-04-22-issue-118-backup-monitoring-design.md)

--- a/docs/runbook-restore.md
+++ b/docs/runbook-restore.md
@@ -128,26 +128,32 @@ zum Jahrestag der Einführung).
 
 ---
 
-## Heartbeat-Alert erhalten — was tun?
+## Backup-Monitoring-Alarm erhalten — was tun?
 
-Healthchecks.io mailt, wenn > 15 Min kein Ping kam. **Seit 2026-04-22
-(Issue #116) läuft die Machine via `min_machines_running = 1` durchgängig
-— ein Alert ist daher ernst zu nehmen, kein Toleranzband mehr durch
-Machine-Stop.**
+Healthchecks.io mailt, wenn > 25 h kein Ping kam. **Seit 2026-04-22
+(Issue #118) wird der Ping von einer scheduled GitHub Action gesendet,
+nicht mehr vom Server.** Ein Alarm heisst: seit > 25 h wurde in Tigris
+kein frisches Backup-Objekt gefunden *oder* die Action konnte Tigris
+nicht erreichen.
 
-1. `fly status -a olivalle` — Machine muss `started` sein. Falls `stopped`
-   oder `failed`: fly-Problem, `fly machine restart` versuchen, bei
-   Wiederholung fly-Support.
-2. `fly logs -a olivalle --no-tail` — letzte Replikations-Zeilen prüfen.
-   Nach `litestream:` filtern — Replikationsfehler sichtbar?
-3. `fly ssh console -a olivalle` → `ls -la /data/olivalle.db-litestream`
-   → Modifikationszeiten prüfen. Der Heartbeat-Loop (`entrypoint.sh`)
-   verlangt mindestens eine Datei **< 15 Min alt**. Bei ruhiger DB sind
-   einige Minuten Alter normal (Litestream schreibt nur bei tatsächlichen
-   DB-Writes); erst > 15 Min durchgehend ist verdächtig.
-4. Häufigster Fall: Tigris-Credentials rotiert/abgelaufen → neue Keys
-   erzeugen (`fly storage create` hat eine `regen`-Variante oder Bucket
-   neu anlegen) und via `fly secrets set` injizieren.
+1. **GitHub Actions Tab** → Workflow `Backup-Monitoring` → letzten Run-Log
+   prüfen:
+   - `[check_backup] ok, ping sent …` → dann ist's ein Healthchecks.io-
+     seitiges Problem, nicht die Action. Ping-Historie im Healthchecks.io-
+     Dashboard prüfen.
+   - `[check_backup] tigris unreachable: …` → Netzwerk/Auth/Tigris-Outage.
+     GitHub Repo-Secrets mit fly-Secrets abgleichen (siehe unten).
+   - `[check_backup] stale or empty: age=…` → **echtes Problem**:
+     Litestream repliziert nicht mehr.
+2. `fly logs -a olivalle --no-tail | grep litestream` → Replikationsfehler
+   sichtbar?
+3. `fly ssh console -a olivalle` → `ls -la /data/.olivalle.db-litestream`
+   → letzte WAL-Segment-Zeit prüfen.
+4. Häufigster Fall: Tigris-Credentials rotiert/abgelaufen → neu erzeugen
+   (`fly storage` oder Tigris-Dashboard), via `fly secrets set` **und**
+   GitHub Repo-Secrets aktualisieren.
+5. Healthchecks.io-Check testweise via `gh workflow run backup-check.yml`
+   triggern → Ping-Ankunft verifizieren.
 
 ---
 

--- a/docs/superpowers/plans/2026-04-22-issue-118-backup-monitoring.md
+++ b/docs/superpowers/plans/2026-04-22-issue-118-backup-monitoring.md
@@ -1,0 +1,858 @@
+# Externes Backup-Monitoring — Implementation Plan (Issue #118)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Backup-Monitoring vom Server (`entrypoint.sh`) in eine scheduled GitHub Action migrieren, die via S3-API bei Tigris die Frische des Backups prüft und Healthchecks.io pingt.
+
+**Architecture:** Scheduled GitHub Action (1×/Tag) ruft Python-Skript auf, das mit boto3 das neueste Objekt im Tigris-Bucket `olivalle-backup` prüft. Ist es < 24 h alt, wird Healthchecks.io gepingt; sonst silent skip. Grace 25 h auf Healthchecks.io-Seite alarmiert per E-Mail. Der Heartbeat-Loop in `entrypoint.sh` wird ersatzlos entfernt.
+
+**Tech Stack:** Python 3.13, boto3, moto (S3-Mock), pytest, GitHub Actions, Tigris S3-API, Healthchecks.io
+
+**Spec:** [`docs/superpowers/specs/2026-04-22-issue-118-backup-monitoring-design.md`](../specs/2026-04-22-issue-118-backup-monitoring-design.md)
+
+---
+
+## File Structure
+
+**Neu:**
+- `scripts/check_backup.py` — Threshold-Check + Ping-Logik (importierbar + CLI-Entry-Point)
+- `tests/test_check_backup.py` — 4 Unit-Tests mit moto + monkeypatch
+- `.github/workflows/backup-check.yml` — Daily Cron + workflow_dispatch
+
+**Modifiziert:**
+- `pyproject.toml` — `boto3`, `moto` zu Dev-Dependencies
+- `entrypoint.sh` — Zeilen 22-32 (Heartbeat-Loop) entfernen
+- `docs/adr-backup-strategie.md` — zweiter Nachtrag (Monitoring-Umbau)
+- `docs/runbook-restore.md` — Abschnitt "Heartbeat-Alert" → "Backup-Monitoring-Alarm"
+- `README.md` — Zeile im Backup-Abschnitt ergänzen
+
+**Operational (nicht im Code, via Checkliste in Task 11):**
+- GitHub Repo-Secrets setzen (3 Secrets)
+- Healthchecks.io Period/Grace umkonfigurieren + unpausen
+- `fly secrets unset HEALTHCHECKS_URL`
+
+---
+
+## Task 1: Feature-Branch + Dev-Dependencies
+
+**Files:**
+- Modify: `pyproject.toml` (`[project.optional-dependencies].dev`)
+
+- [ ] **Step 1: Feature-Branch anlegen**
+
+```bash
+git checkout -b feat/118-external-backup-monitoring
+```
+
+- [ ] **Step 2: Dev-Dependencies ergänzen**
+
+In `pyproject.toml` innerhalb `[project.optional-dependencies].dev` die Liste so anpassen:
+
+```toml
+dev = [
+    "pytest>=8",
+    "httpx>=0.28",
+    "ruff>=0.9",
+    "boto3>=1.34",
+    "moto[s3]>=5.0",
+]
+```
+
+- [ ] **Step 3: Dependencies installieren**
+
+```bash
+uv sync --extra dev
+```
+
+Expected: `uv.lock` aktualisiert, neue Pakete installiert.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add pyproject.toml uv.lock
+git commit -m "feat(deps): boto3 + moto als dev-deps für Backup-Monitoring (#118)"
+```
+
+---
+
+## Task 2: Test + Implementation — Happy Path (Fresh Object → Ping)
+
+**Files:**
+- Create: `tests/test_check_backup.py`
+- Create: `scripts/check_backup.py`
+
+- [ ] **Step 1: Failing Test schreiben**
+
+Datei `tests/test_check_backup.py` anlegen:
+
+```python
+"""Tests für scripts/check_backup.py (Issue #118)."""
+import os
+import sys
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+import boto3
+import pytest
+from moto import mock_aws
+
+BUCKET = "olivalle-backup"
+PREFIX = "olivalle/"
+ENDPOINT = "https://fly.storage.tigris.dev"
+
+# scripts/ muss auf sys.path, damit `import check_backup` funktioniert
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+
+
+@pytest.fixture
+def env(monkeypatch):
+    """Setzt die 3 Env-Vars, die das Skript erwartet."""
+    monkeypatch.setenv("LITESTREAM_ACCESS_KEY_ID", "test-key")
+    monkeypatch.setenv("LITESTREAM_SECRET_ACCESS_KEY", "test-secret")
+    monkeypatch.setenv("HEALTHCHECKS_URL", "https://hc-ping.example/abc")
+
+
+def _put_object(s3, key: str, age_hours: float) -> None:
+    """Legt ein Objekt mit künstlichem LastModified ab. Moto setzt
+    LastModified auf now(); wir stellen das per freeze_time nicht um,
+    sondern nutzen per-test-Zeit-Kontext via Body + LastModified-Check."""
+    s3.put_object(Bucket=BUCKET, Key=key, Body=b"x")
+    # Hinweis: moto setzt LastModified automatisch auf now(UTC).
+    # Für age-Tests: wir setzen das THRESHOLD_HOURS dynamisch oder
+    # patchen datetime.now() im Modul.
+
+
+@mock_aws
+def test_fresh_object_triggers_ping(env):
+    """Frisches Objekt (jünger als Threshold) → Ping wird gesendet."""
+    s3 = boto3.client("s3", endpoint_url=ENDPOINT, region_name="auto")
+    s3.create_bucket(Bucket=BUCKET)
+    s3.put_object(Bucket=BUCKET, Key=f"{PREFIX}snapshot-latest", Body=b"data")
+
+    import check_backup
+
+    with patch("urllib.request.urlopen") as mock_urlopen:
+        rc = check_backup.main()
+
+    assert rc == 0
+    mock_urlopen.assert_called_once()
+    args, _ = mock_urlopen.call_args
+    assert args[0] == "https://hc-ping.example/abc"
+```
+
+- [ ] **Step 2: Test laufen lassen — erwartet FAIL**
+
+```bash
+uv run pytest tests/test_check_backup.py::test_fresh_object_triggers_ping -v
+```
+
+Expected: `ModuleNotFoundError: No module named 'check_backup'` (weil Skript noch nicht existiert).
+
+- [ ] **Step 3: Minimales Skript implementieren**
+
+Datei `scripts/check_backup.py` anlegen:
+
+```python
+"""Prüft, ob Tigris-Backup frisch ist, und pingt Healthchecks.io.
+
+Issue #118. Entwurfsdokument:
+docs/superpowers/specs/2026-04-22-issue-118-backup-monitoring-design.md
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import urllib.request
+from datetime import datetime, timedelta, timezone
+
+import boto3
+
+BUCKET = "olivalle-backup"
+PREFIX = "olivalle/"
+ENDPOINT = "https://fly.storage.tigris.dev"
+THRESHOLD_HOURS = 24
+
+
+def _newest_object_age(s3) -> timedelta | None:
+    """Alter des neuesten Objekts im Bucket. None falls Bucket leer."""
+    resp = s3.list_objects_v2(Bucket=BUCKET, Prefix=PREFIX)
+    contents = resp.get("Contents", [])
+    if not contents:
+        return None
+    newest = max(o["LastModified"] for o in contents)
+    return datetime.now(timezone.utc) - newest
+
+
+def main() -> int:
+    s3 = boto3.client(
+        "s3",
+        endpoint_url=ENDPOINT,
+        region_name="auto",
+        aws_access_key_id=os.environ["LITESTREAM_ACCESS_KEY_ID"],
+        aws_secret_access_key=os.environ["LITESTREAM_SECRET_ACCESS_KEY"],
+    )
+    age = _newest_object_age(s3)
+    if age is None or age > timedelta(hours=THRESHOLD_HOURS):
+        print(f"[check_backup] stale or empty: age={age}")
+        return 0
+    urllib.request.urlopen(os.environ["HEALTHCHECKS_URL"], timeout=10)
+    print(f"[check_backup] ok, ping sent. age={age}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+- [ ] **Step 4: Test laufen lassen — erwartet PASS**
+
+```bash
+uv run pytest tests/test_check_backup.py::test_fresh_object_triggers_ping -v
+```
+
+Expected: `PASSED`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/check_backup.py tests/test_check_backup.py
+git commit -m "feat(scripts): check_backup Happy Path — frisches Objekt triggert Ping (#118)"
+```
+
+---
+
+## Task 3: Test — Stale Object → Silent Skip
+
+**Files:**
+- Modify: `tests/test_check_backup.py` (neuer Test)
+
+**Hinweis (Stand nach Task 2):** Tests verwenden `MagicMock` auf `boto3.client` statt moto — moto kann Calls mit custom `endpoint_url` nicht sauber mocken. Hilfsfunktion `_make_s3_with_object(age)` aus Task 2 wird hier genutzt.
+
+- [ ] **Step 1: Failing Test schreiben**
+
+An `tests/test_check_backup.py` anhängen (nach `test_fresh_object_triggers_ping`):
+
+```python
+def test_stale_object_skips_ping(env):
+    """Objekt > 24h alt → kein Ping."""
+    import check_backup
+
+    fake_s3 = _make_s3_with_object(timedelta(hours=30))
+    with (
+        patch.object(check_backup.boto3, "client", return_value=fake_s3),
+        patch("urllib.request.urlopen") as mock_urlopen,
+    ):
+        rc = check_backup.main()
+
+    assert rc == 0
+    mock_urlopen.assert_not_called()
+```
+
+- [ ] **Step 2: Test laufen lassen — erwartet PASS**
+
+```bash
+uv run pytest tests/test_check_backup.py::test_stale_object_skips_ping -v
+```
+
+Expected: `PASSED` (die Logik `age > THRESHOLD_HOURS` ist bereits aus Task 2 da).
+
+- [ ] **Step 3: Alle Tests laufen lassen — nichts kaputt gemacht**
+
+```bash
+uv run pytest tests/test_check_backup.py -v
+```
+
+Expected: 2 PASSED.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/test_check_backup.py
+git commit -m "test: stale object skippt Ping (#118)"
+```
+
+---
+
+## Task 4: Test — Empty Bucket → Silent Skip
+
+**Files:**
+- Modify: `tests/test_check_backup.py`
+
+- [ ] **Step 1: Failing Test schreiben**
+
+An `tests/test_check_backup.py` anhängen:
+
+```python
+def test_empty_bucket_skips_ping(env):
+    """Leerer Bucket → kein Ping, exit 0."""
+    import check_backup
+
+    fake_s3 = _make_s3_with_object(None)
+    with (
+        patch.object(check_backup.boto3, "client", return_value=fake_s3),
+        patch("urllib.request.urlopen") as mock_urlopen,
+    ):
+        rc = check_backup.main()
+
+    assert rc == 0
+    mock_urlopen.assert_not_called()
+```
+
+- [ ] **Step 2: Test laufen lassen — erwartet PASS**
+
+```bash
+uv run pytest tests/test_check_backup.py::test_empty_bucket_skips_ping -v
+```
+
+Expected: `PASSED` (die Logik `age is None` ist bereits aus Task 2 da).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_check_backup.py
+git commit -m "test: empty bucket skippt Ping (#118)"
+```
+
+---
+
+## Task 5: Test + Implementation — API-Fehler → Silent Skip
+
+**Files:**
+- Modify: `tests/test_check_backup.py`
+- Modify: `scripts/check_backup.py` (Try/Except für API-Call hinzufügen)
+
+- [ ] **Step 1: Failing Test schreiben**
+
+An `tests/test_check_backup.py` anhängen:
+
+```python
+def test_api_error_silent_skip(env, monkeypatch, capsys):
+    """boto3.client wirft Exception → kein Ping, exit 0, Log enthält 'tigris unreachable'."""
+    import check_backup
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("simulated tigris outage")
+
+    with (
+        patch.object(check_backup.boto3, "client", side_effect=boom),
+        patch("urllib.request.urlopen") as mock_urlopen,
+    ):
+        rc = check_backup.main()
+
+    assert rc == 0
+    mock_urlopen.assert_not_called()
+    captured = capsys.readouterr()
+    assert "tigris unreachable" in captured.err
+```
+
+- [ ] **Step 2: Test laufen lassen — erwartet FAIL**
+
+```bash
+uv run pytest tests/test_check_backup.py::test_api_error_silent_skip -v
+```
+
+Expected: `FAIL — RuntimeError: simulated tigris outage` (keine Exception-Handhabung im Skript).
+
+- [ ] **Step 3: Try/Except in `scripts/check_backup.py` einbauen**
+
+In `scripts/check_backup.py` die `main()`-Funktion ersetzen durch:
+
+```python
+def main() -> int:
+    try:
+        s3 = boto3.client(
+            "s3",
+            endpoint_url=ENDPOINT,
+            region_name="auto",
+            aws_access_key_id=os.environ["LITESTREAM_ACCESS_KEY_ID"],
+            aws_secret_access_key=os.environ["LITESTREAM_SECRET_ACCESS_KEY"],
+        )
+        age = _newest_object_age(s3)
+    except Exception as e:
+        print(f"[check_backup] tigris unreachable: {e}", file=sys.stderr)
+        return 0
+    if age is None or age > timedelta(hours=THRESHOLD_HOURS):
+        print(f"[check_backup] stale or empty: age={age}")
+        return 0
+    urllib.request.urlopen(os.environ["HEALTHCHECKS_URL"], timeout=10)
+    print(f"[check_backup] ok, ping sent. age={age}")
+    return 0
+```
+
+- [ ] **Step 4: Test laufen lassen — erwartet PASS**
+
+```bash
+uv run pytest tests/test_check_backup.py::test_api_error_silent_skip -v
+```
+
+Expected: `PASSED`.
+
+- [ ] **Step 5: Alle Tests zusammen**
+
+```bash
+uv run pytest tests/test_check_backup.py -v
+```
+
+Expected: 4 PASSED.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/check_backup.py tests/test_check_backup.py
+git commit -m "feat(scripts): API-Fehler silent-skippen (#118)"
+```
+
+---
+
+## Task 6: GitHub Actions Workflow
+
+**Files:**
+- Create: `.github/workflows/backup-check.yml`
+
+- [ ] **Step 1: Workflow-Datei erstellen**
+
+Datei `.github/workflows/backup-check.yml`:
+
+```yaml
+name: Backup-Monitoring
+
+on:
+  schedule:
+    - cron: '17 5 * * *'
+  workflow_dispatch:
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: Prüft Tigris-Backup-Frische
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
+        with:
+          python-version: "3.13"
+
+      - name: Install dependencies
+        run: uv sync --extra dev
+
+      - name: Check backup freshness
+        run: uv run python scripts/check_backup.py
+        env:
+          LITESTREAM_ACCESS_KEY_ID: ${{ secrets.LITESTREAM_ACCESS_KEY_ID }}
+          LITESTREAM_SECRET_ACCESS_KEY: ${{ secrets.LITESTREAM_SECRET_ACCESS_KEY }}
+          HEALTHCHECKS_URL: ${{ secrets.HEALTHCHECKS_URL }}
+```
+
+**SHA-Hinweis:** Die beiden `uses:`-Zeilen sind 1:1 aus `.github/workflows/deploy.yml` übernommen (identische Action-Versionen → SHA-Pinning konsistent mit Memory-Regel `feedback_github_actions_sha_pinning`).
+
+- [ ] **Step 2: YAML-Syntax prüfen (lokal, mit yamllint falls installiert, sonst Sichtprüfung)**
+
+```bash
+python -c "import yaml; yaml.safe_load(open('.github/workflows/backup-check.yml'))" && echo "YAML OK"
+```
+
+Expected: `YAML OK`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/backup-check.yml
+git commit -m "feat(ci): Scheduled GitHub Action für Backup-Monitoring (#118)"
+```
+
+---
+
+## Task 7: Heartbeat-Loop aus entrypoint.sh entfernen
+
+**Files:**
+- Modify: `entrypoint.sh`
+
+Vor-Zustand (`entrypoint.sh`):
+
+```sh
+#!/bin/sh
+# entrypoint.sh
+# Startet Litestream (PID 1) + uvicorn. Restored bei leerem Volume automatisch
+# und pingt Healthchecks.io periodisch, solange Litestream repliziert.
+set -eu
+
+DB_PATH="${DATABASE_PATH:-/data/olivalle.db}"
+STATE_DIR="${DB_PATH}-litestream"
+HEARTBEAT_URL="${HEALTHCHECKS_URL:-}"
+
+# 1) Auto-Restore bei leerem Volume
+if [ ! -f "$DB_PATH" ]; then
+  echo "[entrypoint] Keine DB gefunden — versuche Restore aus Tigris…"
+  litestream restore -if-replica-exists -config /etc/litestream.yml "$DB_PATH" || {
+    echo "[entrypoint] Kein Backup vorhanden (erstes Deployment) — frische DB."
+  }
+fi
+
+# 2) Migrationen (idempotent, auf Volume)
+python -c 'from app.database import init_db; init_db()'
+
+# 3) Heartbeat-Loop im Hintergrund
+if [ -n "$HEARTBEAT_URL" ]; then
+  (
+    while true; do
+      sleep 600
+      if find "$STATE_DIR" -type f -mmin -15 2>/dev/null | grep -q .; then
+        curl -fsS -m 10 --retry 3 -o /dev/null "$HEARTBEAT_URL" || true
+      fi
+    done
+  ) &
+fi
+
+# 4) Litestream als PID 1, uvicorn als ueberwachter Subprocess
+exec litestream replicate -config /etc/litestream.yml -exec \
+  "uvicorn app.main:app --host 0.0.0.0 --port 8000 --proxy-headers --forwarded-allow-ips=*"
+```
+
+- [ ] **Step 1: Heartbeat-Loop + unnötige Variablen entfernen**
+
+`entrypoint.sh` komplett ersetzen durch:
+
+```sh
+#!/bin/sh
+# entrypoint.sh
+# Startet Litestream (PID 1) + uvicorn. Restored bei leerem Volume automatisch.
+# Backup-Monitoring läuft extern via GitHub Action (siehe
+# .github/workflows/backup-check.yml, Issue #118).
+set -eu
+
+DB_PATH="${DATABASE_PATH:-/data/olivalle.db}"
+
+# 1) Auto-Restore bei leerem Volume
+if [ ! -f "$DB_PATH" ]; then
+  echo "[entrypoint] Keine DB gefunden — versuche Restore aus Tigris…"
+  litestream restore -if-replica-exists -config /etc/litestream.yml "$DB_PATH" || {
+    echo "[entrypoint] Kein Backup vorhanden (erstes Deployment) — frische DB."
+  }
+fi
+
+# 2) Migrationen (idempotent, auf Volume)
+python -c 'from app.database import init_db; init_db()'
+
+# 3) Litestream als PID 1, uvicorn als ueberwachter Subprocess
+exec litestream replicate -config /etc/litestream.yml -exec \
+  "uvicorn app.main:app --host 0.0.0.0 --port 8000 --proxy-headers --forwarded-allow-ips=*"
+```
+
+- [ ] **Step 2: Syntax-Check**
+
+```bash
+sh -n entrypoint.sh && echo "sh-syntax OK"
+```
+
+Expected: `sh-syntax OK`.
+
+- [ ] **Step 3: Diff visuell prüfen**
+
+```bash
+git diff entrypoint.sh
+```
+
+Expected: Zeilen 9 (`STATE_DIR`), 10 (`HEARTBEAT_URL`), und der gesamte Heartbeat-Block (ehemals 22-32) sind weg. Kommentar oben angepasst, Nummerierung 1-3 statt 1-4.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add entrypoint.sh
+git commit -m "refactor(entrypoint): Heartbeat-Loop ersatzlos entfernt (#118)"
+```
+
+---
+
+## Task 8: ADR-Nachtrag
+
+**Files:**
+- Modify: `docs/adr-backup-strategie.md`
+
+- [ ] **Step 1: Zweiten Nachtrag am Dateiende anhängen**
+
+An `docs/adr-backup-strategie.md` anfügen (nach dem #116-Nachtrag):
+
+```markdown
+
+---
+
+## Nachtrag 2026-04-22b: Monitoring-Architektur-Umbau (Issue #118)
+
+**Kontext:** Nach Inbetriebnahme von #110 und #116 zeigten sich zwei Probleme am sekundären Heartbeat-Loop in `entrypoint.sh`:
+
+1. **Pfad-Bug:** Loop prüfte `/data/olivalle.db-litestream`, Litestream schreibt aber in `/data/.olivalle.db-litestream` (Dotfile) — kein einziger Ping seit #110 kam an.
+2. **Falsche Mess-Semantik:** Loop prüfte einen Zwischenschritt auf dem Server (lokale Litestream-Dateien), nicht das Ergebnis in der Cloud (Tigris-Replikat aktuell?).
+
+**Entscheidung:** Backup-Monitoring migriert in eine **scheduled GitHub Action** (`.github/workflows/backup-check.yml`, 1×/Tag), die via S3-API bei Tigris prüft, ob das neueste Objekt < 24 h alt ist. Bei OK → Ping an Healthchecks.io, sonst silent skip. Grace 25 h alarmiert per E-Mail.
+
+Damit wird das im #116-Nachtrag verworfene Argument ("Komplexität nicht lohnend für CHF 1.40/Mt Kostenersparnis") überholt — **nicht Kosten treiben den Wechsel, sondern Korrektheit**.
+
+**Konsequenzen:**
+- Heartbeat-Loop aus `entrypoint.sh` entfernt; Variablen `STATE_DIR` und `HEARTBEAT_URL` weg.
+- `HEALTHCHECKS_URL` wandert von fly-Secret nach GitHub Repo-Secret.
+- Healthchecks.io-Check `olivalle-litestream-heartbeat` umkonfiguriert: Period `10 min` → `1 day`, Grace `5 min` → `25 h`. Name + Ping-URL bleiben, Historie erhalten.
+- Credentials: bestehende `LITESTREAM_*`-Keys werden wiederverwendet (read-only im S3-ListObjectsV2-Kontext).
+
+**Tradeoff:** Bei Tigris-API-Ausfall `silent skip` statt `fail loud` — verhindert false-alarm-Mails bei kurzen Hickups, verzögert aber den Alarm bei mehrtägigem Tigris-Ausfall auf ~48 h. Für Olivalle-Scale akzeptabel.
+
+**Details:** [`docs/superpowers/specs/2026-04-22-issue-118-backup-monitoring-design.md`](superpowers/specs/2026-04-22-issue-118-backup-monitoring-design.md)
+```
+
+- [ ] **Step 2: Markdown-Link-Rendering prüfen (Sichtprüfung im Editor oder Preview)**
+
+Expected: Der Link zum Spec-File sollte klickbar sein (relativer Pfad stimmt).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/adr-backup-strategie.md
+git commit -m "docs(adr): Nachtrag 2026-04-22b — Monitoring-Umbau (#118)"
+```
+
+---
+
+## Task 9: Runbook aktualisieren
+
+**Files:**
+- Modify: `docs/runbook-restore.md` (Abschnitt "Heartbeat-Alert erhalten — was tun?")
+
+- [ ] **Step 1: Bestehenden Abschnitt ersetzen**
+
+In `docs/runbook-restore.md` den **gesamten Block** `## Heartbeat-Alert erhalten — was tun?` inklusive Inhalt **und** der folgenden `---`-Trennlinie (aktuell ~Zeilen 131-153) ersetzen durch das untenstehende Markdown (das neue Section plus `---`-Trennlinie). Der Abschnitt `## Anhang: Protokoll der Restore-Tests` bleibt unangetastet.
+
+```markdown
+## Backup-Monitoring-Alarm erhalten — was tun?
+
+Healthchecks.io mailt, wenn > 25 h kein Ping kam. **Seit 2026-04-22
+(Issue #118) wird der Ping von einer scheduled GitHub Action gesendet,
+nicht mehr vom Server.** Ein Alarm heisst: seit > 25 h wurde in Tigris
+kein frisches Backup-Objekt gefunden *oder* die Action konnte Tigris
+nicht erreichen.
+
+1. **GitHub Actions Tab** → Workflow `Backup-Monitoring` → letzten Run-Log
+   prüfen:
+   - `[check_backup] ok, ping sent …` → dann ist's ein Healthchecks.io-
+     seitiges Problem, nicht die Action. Ping-Historie im Healthchecks.io-
+     Dashboard prüfen.
+   - `[check_backup] tigris unreachable: …` → Netzwerk/Auth/Tigris-Outage.
+     GitHub Repo-Secrets mit fly-Secrets abgleichen (siehe unten).
+   - `[check_backup] stale or empty: age=…` → **echtes Problem**:
+     Litestream repliziert nicht mehr.
+2. `fly logs -a olivalle --no-tail | grep litestream` → Replikationsfehler
+   sichtbar?
+3. `fly ssh console -a olivalle` → `ls -la /data/.olivalle.db-litestream`
+   → letzte WAL-Segment-Zeit prüfen.
+4. Häufigster Fall: Tigris-Credentials rotiert/abgelaufen → neu erzeugen
+   (`fly storage` oder Tigris-Dashboard), via `fly secrets set` **und**
+   GitHub Repo-Secrets aktualisieren.
+5. Healthchecks.io-Check testweise via `gh workflow run backup-check.yml`
+   triggern → Ping-Ankunft verifizieren.
+
+---
+```
+
+- [ ] **Step 2: Diff visuell prüfen**
+
+```bash
+git diff docs/runbook-restore.md
+```
+
+Expected: Alter Abschnitt "Heartbeat-Alert erhalten" komplett ersetzt; Anhang (Protokoll-Tabelle) unberührt.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/runbook-restore.md
+git commit -m "docs(runbook): Backup-Monitoring-Alarm statt Heartbeat-Alert (#118)"
+```
+
+---
+
+## Task 10: README-Zeile ergänzen
+
+**Files:**
+- Modify: `README.md` (Abschnitt "Backups & Wiederherstellung", Zeilen 27-35)
+
+- [ ] **Step 1: Monitoring-Zeile einfügen**
+
+In `README.md` den Abschnitt anpassen. Aktuell:
+
+```markdown
+## Backups & Wiederherstellung
+
+Die SQLite-DB wird kontinuierlich via [Litestream](https://litestream.io)
+in einen Tigris-Bucket (EU-Multi-Region: Amsterdam + Frankfurt) repliziert.
+Im Katastrophenfall (Volume-Verlust) restored der Container automatisch
+beim Start.
+
+- Architekturentscheidung: [`docs/adr-backup-strategie.md`](docs/adr-backup-strategie.md)
+- Restore-Anleitung: [`docs/runbook-restore.md`](docs/runbook-restore.md)
+```
+
+Ersetzen durch:
+
+```markdown
+## Backups & Wiederherstellung
+
+Die SQLite-DB wird kontinuierlich via [Litestream](https://litestream.io)
+in einen Tigris-Bucket (EU-Multi-Region: Amsterdam + Frankfurt) repliziert.
+Im Katastrophenfall (Volume-Verlust) restored der Container automatisch
+beim Start. Eine tägliche GitHub Action prüft die Backup-Frische gegen
+Healthchecks.io (Alarm bei Stillstand > 25 h).
+
+- Architekturentscheidung: [`docs/adr-backup-strategie.md`](docs/adr-backup-strategie.md)
+- Restore-Anleitung: [`docs/runbook-restore.md`](docs/runbook-restore.md)
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add README.md
+git commit -m "docs(readme): Backup-Monitoring-Zeile ergänzt (#118)"
+```
+
+---
+
+## Task 11: Operational Checklist (nicht-code, manuell nach PR-Merge)
+
+**Files:** keine Code-Änderung; diese Checkliste als Kommentar im PR-Body verwenden.
+
+- [ ] **Step 1: GitHub Repo-Secrets setzen**
+
+```bash
+# Werte aus fly holen (einmalig)
+fly ssh console -a olivalle -C 'printenv LITESTREAM_ACCESS_KEY_ID'
+fly ssh console -a olivalle -C 'printenv LITESTREAM_SECRET_ACCESS_KEY'
+fly ssh console -a olivalle -C 'printenv HEALTHCHECKS_URL'
+```
+
+Dann in GitHub: Repo → Settings → Secrets and variables → Actions → New repository secret. Drei Secrets anlegen:
+- `LITESTREAM_ACCESS_KEY_ID`
+- `LITESTREAM_SECRET_ACCESS_KEY`
+- `HEALTHCHECKS_URL`
+
+- [ ] **Step 2: Action testweise triggern (Branch noch nicht gemergt)**
+
+```bash
+gh workflow run backup-check.yml --ref feat/118-external-backup-monitoring
+gh run list --workflow=backup-check.yml --limit 1
+```
+
+Expected: Action-Run endet mit exit 0, Log zeigt `[check_backup] ok, ping sent. age=…`.
+
+- [ ] **Step 3: Healthchecks.io-UI: Ping-Ankunft verifizieren**
+
+Im Healthchecks.io-Dashboard den Check `olivalle-litestream-heartbeat` öffnen. Unter "Events" sollte ein Ping von ~jetzt sichtbar sein (auch wenn Check pausiert ist, wird der Ping geloggt).
+
+- [ ] **Step 4: Healthchecks.io-Check umkonfigurieren + unpausen**
+
+- Period: `10 min` → `1 day`
+- Grace: `5 min` → `25 h`
+- Save → **Unpause**
+
+- [ ] **Step 5: PR mergen**
+
+Über GitHub-UI oder `gh pr merge`. Deploy rollt automatisch.
+
+- [ ] **Step 6: Fly-Secret entfernen (erst nach erfolgreichem Deploy)**
+
+```bash
+fly secrets unset HEALTHCHECKS_URL -a olivalle
+```
+
+- [ ] **Step 7: 7 Tage Beobachtungsfenster starten**
+
+Kalendereintrag für 2026-04-29 setzen: "Issue #118 schliessen wenn 7 Tage keine false-positives". Bis dahin täglich einen Blick auf GitHub Actions Tab und Healthchecks.io-Log werfen.
+
+---
+
+## Task 12: Lint + Full-Test-Run vor PR
+
+**Files:** keine
+
+- [ ] **Step 1: Ruff auf neuen Code**
+
+```bash
+uv run ruff check scripts/ tests/test_check_backup.py
+uv run ruff format --check scripts/ tests/test_check_backup.py
+```
+
+Expected: `All checks passed!` und `would reformat 0 files` (oder 0 Findings).
+
+- [ ] **Step 2: Pytest Full Run**
+
+```bash
+uv run pytest
+```
+
+Expected: alle Tests PASS, inklusive der 4 neuen in `test_check_backup.py`.
+
+- [ ] **Step 3: Make-Lint-All (falls vorhanden)**
+
+```bash
+make lint-all
+```
+
+Expected: keine neuen Findings.
+
+- [ ] **Step 4: PR eröffnen**
+
+```bash
+gh pr create --title "feat: Externes Backup-Monitoring via GitHub Action (#118)" --body "$(cat <<'EOF'
+## Summary
+
+- Neue scheduled GitHub Action `backup-check.yml` prüft täglich via S3-API bei Tigris, ob das neueste Objekt im Bucket `olivalle-backup` < 24 h alt ist. Bei OK → Ping an Healthchecks.io, sonst silent skip.
+- Heartbeat-Loop aus `entrypoint.sh` ersatzlos entfernt — hatte Pfad-Bug (`.olivalle.db-litestream` vs `olivalle.db-litestream`) und mass am falschen Ende (Server-Zwischenschritt statt Cloud-Ergebnis).
+- Doku: ADR-Nachtrag 2026-04-22b, Runbook-Abschnitt "Backup-Monitoring-Alarm erhalten", README-Zeile ergänzt.
+
+Spec: `docs/superpowers/specs/2026-04-22-issue-118-backup-monitoring-design.md`
+
+## Test plan
+
+- [ ] `uv run pytest tests/test_check_backup.py -v` → 4 PASSED
+- [ ] `make lint-all` → keine neuen Findings
+- [ ] GitHub Repo-Secrets gesetzt (LITESTREAM_*, HEALTHCHECKS_URL)
+- [ ] `gh workflow run backup-check.yml --ref feat/118-external-backup-monitoring` → ok, ping sent
+- [ ] Healthchecks.io-Check Period/Grace umkonfiguriert + unpausen
+- [ ] Merge + Deploy → fly-Logs ohne Heartbeat-Block
+- [ ] `fly secrets unset HEALTHCHECKS_URL -a olivalle`
+- [ ] 7 Tage Beobachtung ohne false-positives
+
+Closes #118
+EOF
+)"
+```
+
+---
+
+## Self-Review (durchgeführt)
+
+**Spec-Coverage:**
+- ✅ D1 (täglich + Grace 25h) — Task 6 (cron) + Task 11 Step 4 (Grace-Config)
+- ✅ D2 (Credential-Reuse) — Task 11 Step 1
+- ✅ D3 (Python + pytest + moto) — Tasks 1-5
+- ✅ D4 (silent skip) — Task 5 (Try/Except)
+- ✅ D5 (Cleanup) — Task 7 (entrypoint), Task 11 Step 4 (HC.io), Task 11 Step 6 (fly-secret)
+- ✅ Komponenten `check_backup.py` + Tests — Tasks 2-5
+- ✅ Workflow-YAML — Task 6
+- ✅ Doku-Updates — Tasks 8, 9, 10
+- ✅ Acceptance-Criteria — im PR-Body + 7-Tage-Fenster Task 11 Step 7
+
+**Placeholder-Scan:**
+- Keine TBDs, TODOs, "implement later" in Tasks.
+- Jeder Code-Step enthält vollständigen Code oder exakte Edit-Anweisung.
+- SHAs in Workflow sind konkret aus `deploy.yml` übernommen, nicht als `<SHA>`.
+
+**Type/Name-Konsistenz:**
+- `_newest_object_age` (Task 2) → gleiche Signatur in Task 5 (Refactor berührt sie nicht).
+- Env-Vars `LITESTREAM_ACCESS_KEY_ID`, `LITESTREAM_SECRET_ACCESS_KEY`, `HEALTHCHECKS_URL` identisch in Skript, Workflow, Test-Fixture.
+- `THRESHOLD_HOURS = 24` konsistent.
+- Bucket `olivalle-backup`, Prefix `olivalle/`, Endpoint `https://fly.storage.tigris.dev` identisch in Skript und Tests.

--- a/docs/superpowers/specs/2026-04-22-issue-118-backup-monitoring-design.md
+++ b/docs/superpowers/specs/2026-04-22-issue-118-backup-monitoring-design.md
@@ -1,0 +1,306 @@
+# Design: Externes Backup-Monitoring (Issue #118)
+
+**Status:** Entwurf (2026-04-22)
+**Issue:** [#118](https://github.com/konstantinniedermann/olivalle-webshop/issues/118)
+**Relates to:** [#110](https://github.com/konstantinniedermann/olivalle-webshop/issues/110) (Litestream-Setup), [#116](https://github.com/konstantinniedermann/olivalle-webshop/issues/116) (min_machines_running=1)
+
+## Kontext
+
+Mit #110 ist Litestream + Tigris als Backup live, mit #116 läuft die
+fly-Machine 24/7. Nach Inbetriebnahme zeigten sich zwei Probleme am
+**sekundären Heartbeat-Loop** in `entrypoint.sh:22-32`:
+
+1. **Pfad-Bug:** Der Loop prüft `/data/olivalle.db-litestream`, Litestream
+   schreibt aber in `/data/.olivalle.db-litestream` (Dotfile). Seit #110
+   kam dadurch kein einziger Ping bei Healthchecks.io an — fiel erst nach
+   dem ersten vollen Loop-Durchlauf nach #116 auf.
+2. **Falsche Mess-Semantik:** Der Loop prüft einen Zwischenschritt auf dem
+   Server (lokale Litestream-Dateien), nicht das **Ergebnis in der Cloud**
+   (Tigris-Replikat aktuell?). Selbst wenn der Pfad-Bug behoben wäre,
+   würde bei ruhiger DB (lange Stille-Phasen ohne Writes) regelmässig ein
+   false-positive Alarm drohen.
+
+Zusätzlich hatte der #116-ADR-Nachtrag die Option "Externer Cron gegen
+Tigris" noch verworfen mit dem Argument "mehr Komplexität, neue Secrets,
+nicht lohnend für CHF 1.40/Mt Kostenersparnis". Durch die oben genannten
+Bugs kehrt sich die Abwägung um: **nicht Kosten treiben den Wechsel,
+sondern Korrektheit**.
+
+## Ziel
+
+Backup-Monitoring misst das **Ergebnis** (frisches Objekt im Cloud-Bucket?)
+statt eines Server-internen Zwischenschritts. Betriebsmodell:
+
+- **Scheduled GitHub Action** (1×/Tag) prüft via S3-API bei Tigris, ob
+  das neueste Objekt im Bucket `olivalle-backup` < 24 h alt ist.
+- Bei **OK** → Ping an Healthchecks.io.
+- Bei **stale / leer / API-Fehler** → kein Ping; Healthchecks.io alarmiert
+  per E-Mail nach Ablauf der Grace-Period (25 h).
+- Der sekundäre Heartbeat-Loop in `entrypoint.sh` wird **ersatzlos
+  entfernt** — die Litestream-Replikation selbst bleibt unverändert.
+
+## Design-Entscheidungen
+
+### D1: Prüffrequenz — täglich + Grace 25 h
+
+**Entscheidung:** `cron: '17 5 * * *'` (05:17 UTC ≈ 07:17 CH-Sommerzeit),
+Threshold in der Action 24 h, Healthchecks.io Grace 25 h (1 h Puffer).
+
+**Verworfen:** stündlich (2 h Grace) — schnellerer Alarm, aber für einen
+Einzelunternehmer-Shop mit manueller Reaktion überdimensioniert.
+
+**Begründung Uhrzeit:** Frühmorgens heisst, ein möglicher Alarm erreicht
+den Entwickler beim Aufstehen, nicht mitten in der Nacht. Minute `:17`
+vermeidet GitHub-Peak zur vollen Stunde.
+
+### D2: Credentials — Wiederverwendung der Litestream-Keys
+
+**Entscheidung:** Die bestehenden Secrets `LITESTREAM_ACCESS_KEY_ID` und
+`LITESTREAM_SECRET_ACCESS_KEY` werden einmalig aus den fly-Secrets
+übernommen und als **GitHub Repo-Secrets** eingetragen. Die GitHub Action
+nutzt sie read-only (sie macht nur `ListObjectsV2`).
+
+**Verworfen:** Separate read-only-Keys via Tigris-Dashboard erzeugen.
+Principle of Least Privilege wäre technisch sauberer, würde aber Handarbeit
+im Tigris-Dashboard erfordern und ein weiteres Secret-Paar zu pflegen
+hinzufügen. Für Single-Dev + Private-Repo ist der reale Angriffsvektor
+nicht wesentlich grösser.
+
+### D3: Implementierung — Python-Skript + pytest
+
+**Entscheidung:** Threshold-Logik in `scripts/check_backup.py`, testbar
+mit `pytest` + `moto`. Workflow ruft `uv run python scripts/check_backup.py`
+auf.
+
+**Verworfen:** Inline-Bash im Workflow — nicht isoliert testbar, und
+Threshold-Logik ist genau die Stelle wo Off-by-one-Bugs entstehen (siehe
+Pfad-Bug im bisherigen Heartbeat). Auch verworfen: Marketplace-Action —
+zusätzliche Dependency, SHA-Pinning-Pflege, intransparent für diesen
+simplen Use-Case.
+
+### D4: Error-Handling — Silent Skip
+
+**Entscheidung:** Bei Tigris-API-Fehler (Netzwerk, 5xx, Auth, leerer
+Bucket) → Log-Ausgabe, **kein Ping**, Action exit 0. Healthchecks.io
+alarmiert nach Ablauf der Grace-Period falls der Zustand anhält.
+
+**Verworfen:** "Fail loud" (action exit 1, GitHub-E-Mail zusätzlich zu
+Healthchecks.io) — bewusst gegen Dual-Channel entschieden, weil ein
+kurzer Tigris-Hiccup sonst sofortige false-alarm-Mails triggert. Tradeoff:
+Ein mehrstündiger Tigris-Ausfall kann bis zu ~2 Tage unbemerkt bleiben
+(heutiger Run fällt, morgen ist Tigris wieder ok, übermorgen hätte
+Grace-Period Alarm ausgelöst). Für Olivalle-Scale akzeptabel.
+
+### D5: Cleanup-Strategie — Heartbeat raus, Check umkonfigurieren
+
+**Entscheidung:**
+
+- `entrypoint.sh:22-32` (Heartbeat-Loop) ersatzlos entfernen; Variablen
+  `STATE_DIR` und `HEARTBEAT_URL` mitentfernen.
+- `fly secrets unset HEALTHCHECKS_URL -a olivalle` nach erstem
+  erfolgreichen Action-Run.
+- **Bestehenden** Healthchecks.io-Check (`olivalle-litestream-heartbeat`)
+  umkonfigurieren: Period `10 min` → `1 day`, Grace `5 min` → `25 h`,
+  Check unpausen. Name + Ping-URL bleiben, Historie bleibt erhalten.
+
+**Verworfen:** Neuen Check anlegen + alten archivieren — saubere Trennung,
+aber Secret-Rotation und History-Verlust sind unnötiger Aufwand.
+
+## Komponenten
+
+### Neu: `scripts/check_backup.py`
+
+```python
+# Skizze, nicht finaler Code
+import os, sys, boto3
+from datetime import datetime, timezone, timedelta
+import urllib.request
+
+BUCKET = "olivalle-backup"
+PREFIX = "olivalle/"
+ENDPOINT = "https://fly.storage.tigris.dev"
+THRESHOLD_HOURS = 24
+
+def newest_object_age(s3) -> timedelta | None:
+    """None falls Bucket leer. Exceptions propagiert der Caller."""
+    resp = s3.list_objects_v2(Bucket=BUCKET, Prefix=PREFIX)
+    contents = resp.get("Contents", [])
+    if not contents:
+        return None
+    newest = max(o["LastModified"] for o in contents)
+    return datetime.now(timezone.utc) - newest
+
+def main() -> int:
+    try:
+        s3 = boto3.client(
+            "s3",
+            endpoint_url=ENDPOINT,
+            region_name="auto",
+            aws_access_key_id=os.environ["LITESTREAM_ACCESS_KEY_ID"],
+            aws_secret_access_key=os.environ["LITESTREAM_SECRET_ACCESS_KEY"],
+        )
+        age = newest_object_age(s3)
+    except Exception as e:
+        print(f"[check_backup] tigris unreachable: {e}", file=sys.stderr)
+        return 0  # silent skip
+
+    if age is None:
+        print("[check_backup] bucket empty — skipping ping")
+        return 0
+    if age > timedelta(hours=THRESHOLD_HOURS):
+        print(f"[check_backup] stale: age={age} > {THRESHOLD_HOURS}h")
+        return 0
+
+    urllib.request.urlopen(os.environ["HEALTHCHECKS_URL"], timeout=10)
+    print(f"[check_backup] ok, ping sent. age={age}")
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+**Note:** Keine `ContinuationToken`-Schleife nötig — Litestream hält den
+Bucket bei Retention 30 Tage weit unter 1000 Objekten (S3-Default-Limit
+von `list_objects_v2`). Falls das mal ansteigt, wäre der Fix eine
+einzeilige Ergänzung; YAGNI für v1.
+
+### Neu: `tests/test_check_backup.py`
+
+4 Tests mit `moto.mock_aws` und `monkeypatch` für den HTTP-Ping:
+
+| Test | Setup | Erwartet |
+|---|---|---|
+| `test_fresh_object_triggers_ping` | Bucket mit Objekt `now-1h` | Ping-Call erfolgt, exit 0 |
+| `test_stale_object_skips_ping` | Objekt `now-30h` | Kein Ping, exit 0 |
+| `test_empty_bucket_skips_ping` | Bucket leer | Kein Ping, exit 0 |
+| `test_api_error_silent_skip` | `list_objects_v2` wirft `ClientError` | Kein Ping, exit 0 |
+
+### Neu: `.github/workflows/backup-check.yml`
+
+```yaml
+name: Backup-Monitoring
+on:
+  schedule:
+    - cron: '17 5 * * *'
+  workflow_dispatch:
+permissions:
+  contents: read
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@<SHA>  # v6.0.2
+      - uses: astral-sh/setup-uv@<SHA>  # v8.1.0
+        with:
+          python-version: "3.13"
+      - run: uv sync --extra dev
+      - run: uv run python scripts/check_backup.py
+        env:
+          LITESTREAM_ACCESS_KEY_ID: ${{ secrets.LITESTREAM_ACCESS_KEY_ID }}
+          LITESTREAM_SECRET_ACCESS_KEY: ${{ secrets.LITESTREAM_SECRET_ACCESS_KEY }}
+          HEALTHCHECKS_URL: ${{ secrets.HEALTHCHECKS_URL }}
+```
+
+SHAs werden bei der Implementierung aus den bestehenden Workflows
+(`deploy.yml`, `lint.yml`) übernommen — Memory-Regel
+`feedback_github_actions_sha_pinning` greift.
+
+### Änderung: `entrypoint.sh`
+
+Zeilen 22-32 (Heartbeat-Loop inkl. Kommentarblock) entfernen. Die
+Variablen `STATE_DIR` und `HEARTBEAT_URL` werden ebenfalls nicht mehr
+gesetzt. `DB_PATH` bleibt, wird weiter von Litestream genutzt.
+
+### Änderung: `pyproject.toml`
+
+`boto3` und `moto` als Dev-Dependencies hinzufügen (Gruppe `dev`, nur
+für CI/Test, nicht im prod-Container).
+
+## Tests
+
+**Unit-Tests:** Laufen im bestehenden `pytest`-Job von `deploy.yml`. Kein
+echter Netzwerk-Call — `moto` mockt S3, `monkeypatch` mockt den HTTP-Ping.
+
+**Smoke-Test (manuell nach Deploy):**
+
+1. `gh workflow run backup-check.yml` → Run-Log prüfen, im
+   Healthchecks.io-Log sollte innerhalb 30 s ein Ping sichtbar sein.
+2. Temporär falsches Secret setzen + `workflow_dispatch` → erwartet:
+   Log zeigt "tigris unreachable", Action exit 0, kein Ping.
+3. Test-Secret wieder zurücksetzen.
+
+## Rollout
+
+Wichtig: Reihenfolge so wählen, dass **kein Überwachungs-Gap** entsteht —
+der alte Heartbeat wird erst entfernt, wenn die neue Action verifiziert
+pingt.
+
+1. Feature-Branch `feat/118-external-backup-monitoring`, alles committen
+   (Script, Tests, Workflow, entrypoint.sh-Änderung, pyproject.toml).
+2. GitHub Repo-Secrets setzen: `LITESTREAM_ACCESS_KEY_ID`,
+   `LITESTREAM_SECRET_ACCESS_KEY`, `HEALTHCHECKS_URL` (aus fly-Secrets
+   übernommen via `fly ssh console -a olivalle -C 'printenv …'`).
+3. Auf dem Branch: `gh workflow run backup-check.yml` → Run-Log prüfen,
+   Ping im Healthchecks.io-Log erwarten.
+4. Healthchecks.io-Dashboard: Check `olivalle-litestream-heartbeat` →
+   Period `1 day`, Grace `25 h`, Check **unpausen**.
+5. PR-Review + Merge → Deploy rollt neue `entrypoint.sh` ohne
+   Heartbeat-Loop aus.
+6. `fly secrets unset HEALTHCHECKS_URL -a olivalle` (Aufräumen).
+7. **7 Tage Beobachtung** (Acceptance-Criterion aus #118).
+
+## Dokumentations-Updates (im selben PR)
+
+1. `docs/adr-backup-strategie.md` — zweiter Nachtrag ("Nachtrag
+   2026-04-22b: Monitoring-Architektur-Umbau") erklärt die Kehrtwende
+   gegenüber dem #116-Nachtrag (Korrektheit, nicht Kosten).
+2. `docs/runbook-restore.md` — Abschnitt "Heartbeat-Alert erhalten"
+   wird zu "Backup-Monitoring-Alarm erhalten": verweist auf GitHub
+   Actions Tab als erste Diagnose-Stelle, nicht mehr auf `fly ssh`.
+3. `README.md` — Abschnitt "Backups & Wiederherstellung" um eine Zeile
+   ergänzen: "Tägliches Monitoring via scheduled GitHub Action prüft
+   Tigris-Frische gegen Healthchecks.io."
+4. `CLAUDE.md` (Projekt) — keine Änderung nötig (Monitoring-Umbau ist
+   Implementierungsdetail, nicht Tech-Stack-Ebene).
+5. Memory-Update `project_backup_setup.md` — nach Merge: "#118
+   Monitoring-Umbau live".
+
+## Akzeptanzkriterien (aus #118 übernommen)
+
+- [ ] GitHub Action läuft nach Zeitplan und pingt bei gesundem Backup an
+      Healthchecks.io.
+- [ ] Manueller Test: Tigris unreachable oder Objekt veraltet → kein
+      Ping → Alarm kommt innerhalb der Grace-Period.
+- [ ] Heartbeat-Loop aus `entrypoint.sh` entfernt.
+- [ ] Doku aktualisiert (ADR-Nachtrag, Runbook, README).
+- [ ] 7 Tage Normalbetrieb ohne false-positives nach Deploy.
+- [ ] Healthchecks.io-Check wieder aktiv.
+
+## Risiken & offene Punkte
+
+**Risiko 1 — Tigris-Ausfall bleibt bis zu 2 Tage unbemerkt (D4-Tradeoff):**
+Bewusst akzeptiert. Bei einem dauerhaften Tigris-Ausfall deckt Grace-Period
+den Fall ab; bei einem einzelnen Hickup ist die Verzögerung akzeptabel.
+
+**Risiko 2 — GitHub Actions Schedule ist best-effort:** GitHub garantiert
+cron-Schedules nicht auf die Minute; bei hoher Last können Runs 15–30 Min
+später kommen. Der 1-Stunden-Puffer (Threshold 24 h vs Grace 25 h) fängt
+das ab.
+
+**Risiko 3 — `list_objects_v2` 1000-Objekte-Limit:** Bei Retention 30 Tage
+und Litestream-Snapshot-Interval 24 h stehen real ~30–60 Objekte im
+Bucket. Weit unter dem Limit; kein Pagination-Code nötig (YAGNI).
+
+**Offen für spätere Issues:**
+- Initialer Restore-Test (#115) — wird nicht Teil dieses PR.
+- Separate Read-Only-Keys (D2, verworfen) — könnten bei späterem
+  Security-Review nachgeholt werden.
+- Externes Uptime-Monitoring für `olivalle.ch` (#111) — separates Thema.
+
+## Referenzen
+
+- Litestream S3-Config: [`litestream.yml`](../../../litestream.yml)
+- ADR: [`docs/adr-backup-strategie.md`](../../adr-backup-strategie.md)
+- Runbook: [`docs/runbook-restore.md`](../../runbook-restore.md)
+- Vorgänger-Spec: [`docs/superpowers/specs/2026-04-22-issue-110-sqlite-backup-design.md`](2026-04-22-issue-110-sqlite-backup-design.md)
+- Vorgänger-Spec: [`docs/superpowers/specs/2026-04-22-issue-116-heartbeat-tuning-design.md`](2026-04-22-issue-116-heartbeat-tuning-design.md)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,12 +1,11 @@
 #!/bin/sh
 # entrypoint.sh
-# Startet Litestream (PID 1) + uvicorn. Restored bei leerem Volume automatisch
-# und pingt Healthchecks.io periodisch, solange Litestream repliziert.
+# Startet Litestream (PID 1) + uvicorn. Restored bei leerem Volume automatisch.
+# Backup-Monitoring läuft extern via GitHub Action (siehe
+# .github/workflows/backup-check.yml, Issue #118).
 set -eu
 
 DB_PATH="${DATABASE_PATH:-/data/olivalle.db}"
-STATE_DIR="${DB_PATH}-litestream"
-HEARTBEAT_URL="${HEALTHCHECKS_URL:-}"
 
 # 1) Auto-Restore bei leerem Volume
 if [ ! -f "$DB_PATH" ]; then
@@ -19,18 +18,6 @@ fi
 # 2) Migrationen (idempotent, auf Volume)
 python -c 'from app.database import init_db; init_db()'
 
-# 3) Heartbeat-Loop im Hintergrund
-if [ -n "$HEARTBEAT_URL" ]; then
-  (
-    while true; do
-      sleep 600
-      if find "$STATE_DIR" -type f -mmin -15 2>/dev/null | grep -q .; then
-        curl -fsS -m 10 --retry 3 -o /dev/null "$HEARTBEAT_URL" || true
-      fi
-    done
-  ) &
-fi
-
-# 4) Litestream als PID 1, uvicorn als ueberwachter Subprocess
+# 3) Litestream als PID 1, uvicorn als ueberwachter Subprocess
 exec litestream replicate -config /etc/litestream.yml -exec \
   "uvicorn app.main:app --host 0.0.0.0 --port 8000 --proxy-headers --forwarded-allow-ips=*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,8 @@ dev = [
     "pytest>=8",
     "httpx>=0.28",
     "ruff>=0.9",
+    "boto3>=1.34",
+    "moto[s3]>=5.0",
 ]
 docs = [
     "mkdocs>=1.6",

--- a/scripts/check_backup.py
+++ b/scripts/check_backup.py
@@ -30,14 +30,18 @@ def _newest_object_age(s3) -> timedelta | None:
 
 
 def main() -> int:
-    s3 = boto3.client(
-        "s3",
-        endpoint_url=ENDPOINT,
-        region_name="auto",
-        aws_access_key_id=os.environ["LITESTREAM_ACCESS_KEY_ID"],
-        aws_secret_access_key=os.environ["LITESTREAM_SECRET_ACCESS_KEY"],
-    )
-    age = _newest_object_age(s3)
+    try:
+        s3 = boto3.client(
+            "s3",
+            endpoint_url=ENDPOINT,
+            region_name="auto",
+            aws_access_key_id=os.environ["LITESTREAM_ACCESS_KEY_ID"],
+            aws_secret_access_key=os.environ["LITESTREAM_SECRET_ACCESS_KEY"],
+        )
+        age = _newest_object_age(s3)
+    except Exception as e:
+        print(f"[check_backup] tigris unreachable: {e}", file=sys.stderr)
+        return 0
     if age is None or age > timedelta(hours=THRESHOLD_HOURS):
         print(f"[check_backup] stale or empty: age={age}")
         return 0

--- a/scripts/check_backup.py
+++ b/scripts/check_backup.py
@@ -1,0 +1,50 @@
+"""Prüft, ob Tigris-Backup frisch ist, und pingt Healthchecks.io.
+
+Issue #118. Entwurfsdokument:
+docs/superpowers/specs/2026-04-22-issue-118-backup-monitoring-design.md
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import urllib.request
+from datetime import UTC, datetime, timedelta
+
+import boto3
+
+BUCKET = "olivalle-backup"
+PREFIX = "olivalle/"
+ENDPOINT = "https://fly.storage.tigris.dev"
+THRESHOLD_HOURS = 24
+
+
+def _newest_object_age(s3) -> timedelta | None:
+    """Alter des neuesten Objekts im Bucket. None falls Bucket leer."""
+    resp = s3.list_objects_v2(Bucket=BUCKET, Prefix=PREFIX)
+    contents = resp.get("Contents", [])
+    if not contents:
+        return None
+    newest = max(o["LastModified"] for o in contents)
+    return datetime.now(UTC) - newest
+
+
+def main() -> int:
+    s3 = boto3.client(
+        "s3",
+        endpoint_url=ENDPOINT,
+        region_name="auto",
+        aws_access_key_id=os.environ["LITESTREAM_ACCESS_KEY_ID"],
+        aws_secret_access_key=os.environ["LITESTREAM_SECRET_ACCESS_KEY"],
+    )
+    age = _newest_object_age(s3)
+    if age is None or age > timedelta(hours=THRESHOLD_HOURS):
+        print(f"[check_backup] stale or empty: age={age}")
+        return 0
+    urllib.request.urlopen(os.environ["HEALTHCHECKS_URL"], timeout=10)
+    print(f"[check_backup] ok, ping sent. age={age}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_check_backup.py
+++ b/tests/test_check_backup.py
@@ -85,7 +85,7 @@ def test_empty_bucket_skips_ping(env):
 
 
 def test_api_error_silent_skip(env, capsys):
-    """boto3.client wirft Exception → kein Ping, exit 0, Log enthält 'tigris unreachable'."""
+    """boto3.client wirft Exception → kein Ping, exit 0, stderr 'tigris unreachable'."""
     import check_backup
 
     def boom(*args, **kwargs):

--- a/tests/test_check_backup.py
+++ b/tests/test_check_backup.py
@@ -82,3 +82,22 @@ def test_empty_bucket_skips_ping(env):
 
     assert rc == 0
     mock_urlopen.assert_not_called()
+
+
+def test_api_error_silent_skip(env, capsys):
+    """boto3.client wirft Exception → kein Ping, exit 0, Log enthält 'tigris unreachable'."""
+    import check_backup
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("simulated tigris outage")
+
+    with (
+        patch.object(check_backup.boto3, "client", side_effect=boom),
+        patch("urllib.request.urlopen") as mock_urlopen,
+    ):
+        rc = check_backup.main()
+
+    assert rc == 0
+    mock_urlopen.assert_not_called()
+    captured = capsys.readouterr()
+    assert "tigris unreachable" in captured.err

--- a/tests/test_check_backup.py
+++ b/tests/test_check_backup.py
@@ -1,4 +1,5 @@
 """Tests für scripts/check_backup.py (Issue #118)."""
+
 import os
 import sys
 from datetime import UTC, datetime, timedelta
@@ -41,8 +42,10 @@ def test_fresh_object_triggers_ping(env):
     import check_backup
 
     fake_s3 = _make_s3_with_object(timedelta(hours=1))
-    with patch.object(check_backup.boto3, "client", return_value=fake_s3), \
-         patch("urllib.request.urlopen") as mock_urlopen:
+    with (
+        patch.object(check_backup.boto3, "client", return_value=fake_s3),
+        patch("urllib.request.urlopen") as mock_urlopen,
+    ):
         rc = check_backup.main()
 
     assert rc == 0

--- a/tests/test_check_backup.py
+++ b/tests/test_check_backup.py
@@ -52,3 +52,18 @@ def test_fresh_object_triggers_ping(env):
     mock_urlopen.assert_called_once()
     args, _ = mock_urlopen.call_args
     assert args[0] == "https://hc-ping.example/abc"
+
+
+def test_stale_object_skips_ping(env):
+    """Objekt > 24h alt → kein Ping."""
+    import check_backup
+
+    fake_s3 = _make_s3_with_object(timedelta(hours=30))
+    with (
+        patch.object(check_backup.boto3, "client", return_value=fake_s3),
+        patch("urllib.request.urlopen") as mock_urlopen,
+    ):
+        rc = check_backup.main()
+
+    assert rc == 0
+    mock_urlopen.assert_not_called()

--- a/tests/test_check_backup.py
+++ b/tests/test_check_backup.py
@@ -1,0 +1,51 @@
+"""Tests für scripts/check_backup.py (Issue #118)."""
+import os
+import sys
+from datetime import UTC, datetime, timedelta
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# scripts/ auf sys.path, damit `import check_backup` funktioniert
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+
+
+def _make_s3_with_object(age: timedelta | None) -> MagicMock:
+    """Fake S3-Client. age=None → leerer Bucket, sonst ein Objekt mit
+    gegebenem Alter (LastModified = now - age)."""
+    fake = MagicMock()
+    if age is None:
+        fake.list_objects_v2.return_value = {}
+    else:
+        fake.list_objects_v2.return_value = {
+            "Contents": [
+                {
+                    "Key": "olivalle/snapshot-latest",
+                    "LastModified": datetime.now(UTC) - age,
+                }
+            ]
+        }
+    return fake
+
+
+@pytest.fixture
+def env(monkeypatch):
+    """Setzt die 3 Env-Vars, die das Skript erwartet."""
+    monkeypatch.setenv("LITESTREAM_ACCESS_KEY_ID", "test-key")
+    monkeypatch.setenv("LITESTREAM_SECRET_ACCESS_KEY", "test-secret")
+    monkeypatch.setenv("HEALTHCHECKS_URL", "https://hc-ping.example/abc")
+
+
+def test_fresh_object_triggers_ping(env):
+    """Frisches Objekt (1h alt) → Ping wird gesendet."""
+    import check_backup
+
+    fake_s3 = _make_s3_with_object(timedelta(hours=1))
+    with patch.object(check_backup.boto3, "client", return_value=fake_s3), \
+         patch("urllib.request.urlopen") as mock_urlopen:
+        rc = check_backup.main()
+
+    assert rc == 0
+    mock_urlopen.assert_called_once()
+    args, _ = mock_urlopen.call_args
+    assert args[0] == "https://hc-ping.example/abc"

--- a/tests/test_check_backup.py
+++ b/tests/test_check_backup.py
@@ -67,3 +67,18 @@ def test_stale_object_skips_ping(env):
 
     assert rc == 0
     mock_urlopen.assert_not_called()
+
+
+def test_empty_bucket_skips_ping(env):
+    """Leerer Bucket → kein Ping, exit 0."""
+    import check_backup
+
+    fake_s3 = _make_s3_with_object(None)
+    with (
+        patch.object(check_backup.boto3, "client", return_value=fake_s3),
+        patch("urllib.request.urlopen") as mock_urlopen,
+    ):
+        rc = check_backup.main()
+
+    assert rc == 0
+    mock_urlopen.assert_not_called()

--- a/uv.lock
+++ b/uv.lock
@@ -135,6 +135,34 @@ wheels = [
 ]
 
 [[package]]
+name = "boto3"
+version = "1.42.93"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dd/ac/e6b2b24d53c830500176f710594efcde626186b5b3c9aead6f8837976956/boto3-1.42.93.tar.gz", hash = "sha256:ff81c6bac708cb95c4f8b27e331ac67d95c6908dd86bcb7b15b8941960f2bc4c", size = 113218, upload-time = "2026-04-21T21:30:39.733Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/2d/fcc35bde9fa47ac463a3023c73838e23e9281cde7f5e86fe7c459c3b72aa/boto3-1.42.93-py3-none-any.whl", hash = "sha256:51e34e30e65bea4df0ff77f91abdcb97297eb74c3b27eb576b2abbd758452967", size = 140554, upload-time = "2026-04-21T21:30:36.581Z" },
+]
+
+[[package]]
+name = "botocore"
+version = "1.42.93"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1b/d4/eb53f7ed81836696abf7103c9c901a0cace9217328094ca93419016a78c9/botocore-1.42.93.tar.gz", hash = "sha256:9ce49863c50b43f7942edd295fb16bfc6d227264ce6fc32c8f2426ef11b9351b", size = 15239759, upload-time = "2026-04-21T21:30:23.707Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/0c/ccc57c9a7bcd4553620bf6f50a3640ba68d189330fc4787dbddb2d851534/botocore-1.42.93-py3-none-any.whl", hash = "sha256:96ae26cd6302a7c7563398517b90a438168a4efdf4f73ab38882cefb8df721cc", size = 14923656, upload-time = "2026-04-21T21:30:17.597Z" },
+]
+
+[[package]]
 name = "brevo-python"
 version = "4.0.9"
 source = { registry = "https://pypi.org/simple" }
@@ -156,6 +184,51 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/af/2d/7bf41579a8986e348fa033a31cdd0e4121114f6bce2457e8876010b092dd/certifi-2026.2.25.tar.gz", hash = "sha256:e887ab5cee78ea814d3472169153c2d12cd43b14bd03329a39a9c6e2e80bfba7", size = 155029, upload-time = "2026-02-25T02:54:17.342Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9a/3c/c17fb3ca2d9c3acff52e30b309f538586f9f5b9c9cf454f3845fc9af4881/certifi-2026.2.25-py3-none-any.whl", hash = "sha256:027692e4402ad994f1c42e52a4997a9763c646b73e4096e4d5d6db8af1d6f0fa", size = 153684, upload-time = "2026-02-25T02:54:15.766Z" },
+]
+
+[[package]]
+name = "cffi"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/8d/a0a47a0c9e413a658623d014e91e74a50cdd2c423f7ccfd44086ef767f90/cffi-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:00bdf7acc5f795150faa6957054fbbca2439db2f775ce831222b66f192f03beb", size = 185230, upload-time = "2025-09-08T23:23:00.879Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/d2/a6c0296814556c68ee32009d9c2ad4f85f2707cdecfd7727951ec228005d/cffi-2.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:45d5e886156860dc35862657e1494b9bae8dfa63bf56796f2fb56e1679fc0bca", size = 181043, upload-time = "2025-09-08T23:23:02.231Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/1e/d22cc63332bd59b06481ceaac49d6c507598642e2230f201649058a7e704/cffi-2.0.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b", size = 212446, upload-time = "2025-09-08T23:23:03.472Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b", size = 220101, upload-time = "2025-09-08T23:23:04.792Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/7f/e6647792fc5850d634695bc0e6ab4111ae88e89981d35ac269956605feba/cffi-2.0.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2", size = 207948, upload-time = "2025-09-08T23:23:06.127Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1e/a5a1bd6f1fb30f22573f76533de12a00bf274abcdc55c8edab639078abb6/cffi-2.0.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:dd4f05f54a52fb558f1ba9f528228066954fee3ebe629fc1660d874d040ae5a3", size = 206422, upload-time = "2025-09-08T23:23:07.753Z" },
+    { url = "https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26", size = 219499, upload-time = "2025-09-08T23:23:09.648Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e1/a969e687fcf9ea58e6e2a928ad5e2dd88cc12f6f0ab477e9971f2309b57c/cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c", size = 222928, upload-time = "2025-09-08T23:23:10.928Z" },
+    { url = "https://files.pythonhosted.org/packages/36/54/0362578dd2c9e557a28ac77698ed67323ed5b9775ca9d3fe73fe191bb5d8/cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b", size = 221302, upload-time = "2025-09-08T23:23:12.42Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/6d/bf9bda840d5f1dfdbf0feca87fbdb64a918a69bca42cfa0ba7b137c48cb8/cffi-2.0.0-cp313-cp313-win32.whl", hash = "sha256:74a03b9698e198d47562765773b4a8309919089150a0bb17d829ad7b44b60d27", size = 172909, upload-time = "2025-09-08T23:23:14.32Z" },
+    { url = "https://files.pythonhosted.org/packages/37/18/6519e1ee6f5a1e579e04b9ddb6f1676c17368a7aba48299c3759bbc3c8b3/cffi-2.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:19f705ada2530c1167abacb171925dd886168931e0a7b78f5bffcae5c6b5be75", size = 183402, upload-time = "2025-09-08T23:23:15.535Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/0e/02ceeec9a7d6ee63bb596121c2c8e9b3a9e150936f4fbef6ca1943e6137c/cffi-2.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:256f80b80ca3853f90c21b23ee78cd008713787b1b1e93eae9f3d6a7134abd91", size = 177780, upload-time = "2025-09-08T23:23:16.761Z" },
+    { url = "https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fc33c5141b55ed366cfaad382df24fe7dcbc686de5be719b207bb248e3053dc5", size = 185320, upload-time = "2025-09-08T23:23:18.087Z" },
+    { url = "https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c654de545946e0db659b3400168c9ad31b5d29593291482c43e3564effbcee13", size = 181487, upload-time = "2025-09-08T23:23:19.622Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b", size = 220049, upload-time = "2025-09-08T23:23:20.853Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/89/76799151d9c2d2d1ead63c2429da9ea9d7aac304603de0c6e8764e6e8e70/cffi-2.0.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c", size = 207793, upload-time = "2025-09-08T23:23:22.08Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/dd/3465b14bb9e24ee24cb88c9e3730f6de63111fffe513492bf8c808a3547e/cffi-2.0.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef", size = 206300, upload-time = "2025-09-08T23:23:23.314Z" },
+    { url = "https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775", size = 219244, upload-time = "2025-09-08T23:23:24.541Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0f/1f177e3683aead2bb00f7679a16451d302c436b5cbf2505f0ea8146ef59e/cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205", size = 222828, upload-time = "2025-09-08T23:23:26.143Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/0f/cafacebd4b040e3119dcb32fed8bdef8dfe94da653155f9d0b9dc660166e/cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1", size = 220926, upload-time = "2025-09-08T23:23:27.873Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/aa/df335faa45b395396fcbc03de2dfcab242cd61a9900e914fe682a59170b1/cffi-2.0.0-cp314-cp314-win32.whl", hash = "sha256:087067fa8953339c723661eda6b54bc98c5625757ea62e95eb4898ad5e776e9f", size = 175328, upload-time = "2025-09-08T23:23:44.61Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:203a48d1fb583fc7d78a4c6655692963b860a417c0528492a6bc21f1aaefab25", size = 185650, upload-time = "2025-09-08T23:23:45.848Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/2c/98ece204b9d35a7366b5b2c6539c350313ca13932143e79dc133ba757104/cffi-2.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:dbd5c7a25a7cb98f5ca55d258b103a2054f859a46ae11aaf23134f9cc0d356ad", size = 180687, upload-time = "2025-09-08T23:23:47.105Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/61/c768e4d548bfa607abcda77423448df8c471f25dbe64fb2ef6d555eae006/cffi-2.0.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:9a67fc9e8eb39039280526379fb3a70023d77caec1852002b4da7e8b270c4dd9", size = 188773, upload-time = "2025-09-08T23:23:29.347Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ea/5f76bce7cf6fcd0ab1a1058b5af899bfbef198bea4d5686da88471ea0336/cffi-2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7a66c7204d8869299919db4d5069a82f1561581af12b11b3c9f48c584eb8743d", size = 185013, upload-time = "2025-09-08T23:23:30.63Z" },
+    { url = "https://files.pythonhosted.org/packages/be/b4/c56878d0d1755cf9caa54ba71e5d049479c52f9e4afc230f06822162ab2f/cffi-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c", size = 221593, upload-time = "2025-09-08T23:23:31.91Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/0d/eb704606dfe8033e7128df5e90fee946bbcb64a04fcdaa97321309004000/cffi-2.0.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8", size = 209354, upload-time = "2025-09-08T23:23:33.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/19/3c435d727b368ca475fb8742ab97c9cb13a0de600ce86f62eab7fa3eea60/cffi-2.0.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc", size = 208480, upload-time = "2025-09-08T23:23:34.495Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/44/681604464ed9541673e486521497406fadcc15b5217c3e326b061696899a/cffi-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592", size = 221584, upload-time = "2025-09-08T23:23:36.096Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8e/342a504ff018a2825d395d44d63a767dd8ebc927ebda557fecdaca3ac33a/cffi-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512", size = 224443, upload-time = "2025-09-08T23:23:37.328Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/5e/b666bacbbc60fbf415ba9988324a132c9a7a0448a9a8f125074671c0f2c3/cffi-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4", size = 223437, upload-time = "2025-09-08T23:23:38.945Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487, upload-time = "2025-09-08T23:23:40.423Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726, upload-time = "2025-09-08T23:23:41.742Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195, upload-time = "2025-09-08T23:23:43.004Z" },
 ]
 
 [[package]]
@@ -234,6 +307,59 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "cryptography"
+version = "46.0.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/47/93/ac8f3d5ff04d54bc814e961a43ae5b0b146154c89c61b47bb07557679b18/cryptography-46.0.7.tar.gz", hash = "sha256:e4cfd68c5f3e0bfdad0d38e023239b96a2fe84146481852dffbcca442c245aa5", size = 750652, upload-time = "2026-04-08T01:57:54.692Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/5d/4a8f770695d73be252331e60e526291e3df0c9b27556a90a6b47bccca4c2/cryptography-46.0.7-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:ea42cbe97209df307fdc3b155f1b6fa2577c0defa8f1f7d3be7d31d189108ad4", size = 7179869, upload-time = "2026-04-08T01:56:17.157Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/45/6d80dc379b0bbc1f9d1e429f42e4cb9e1d319c7a8201beffd967c516ea01/cryptography-46.0.7-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b36a4695e29fe69215d75960b22577197aca3f7a25b9cf9d165dcfe9d80bc325", size = 4275492, upload-time = "2026-04-08T01:56:19.36Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/9a/1765afe9f572e239c3469f2cb429f3ba7b31878c893b246b4b2994ffe2fe/cryptography-46.0.7-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5ad9ef796328c5e3c4ceed237a183f5d41d21150f972455a9d926593a1dcb308", size = 4426670, upload-time = "2026-04-08T01:56:21.415Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/3e/af9246aaf23cd4ee060699adab1e47ced3f5f7e7a8ffdd339f817b446462/cryptography-46.0.7-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:73510b83623e080a2c35c62c15298096e2a5dc8d51c3b4e1740211839d0dea77", size = 4280275, upload-time = "2026-04-08T01:56:23.539Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/54/6bbbfc5efe86f9d71041827b793c24811a017c6ac0fd12883e4caa86b8ed/cryptography-46.0.7-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:cbd5fb06b62bd0721e1170273d3f4d5a277044c47ca27ee257025146c34cbdd1", size = 4928402, upload-time = "2026-04-08T01:56:25.624Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/cf/054b9d8220f81509939599c8bdbc0c408dbd2bdd41688616a20731371fe0/cryptography-46.0.7-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:420b1e4109cc95f0e5700eed79908cef9268265c773d3a66f7af1eef53d409ef", size = 4459985, upload-time = "2026-04-08T01:56:27.309Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/46/4e4e9c6040fb01c7467d47217d2f882daddeb8828f7df800cb806d8a2288/cryptography-46.0.7-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:24402210aa54baae71d99441d15bb5a1919c195398a87b563df84468160a65de", size = 3990652, upload-time = "2026-04-08T01:56:29.095Z" },
+    { url = "https://files.pythonhosted.org/packages/36/5f/313586c3be5a2fbe87e4c9a254207b860155a8e1f3cca99f9910008e7d08/cryptography-46.0.7-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:8a469028a86f12eb7d2fe97162d0634026d92a21f3ae0ac87ed1c4a447886c83", size = 4279805, upload-time = "2026-04-08T01:56:30.928Z" },
+    { url = "https://files.pythonhosted.org/packages/69/33/60dfc4595f334a2082749673386a4d05e4f0cf4df8248e63b2c3437585f2/cryptography-46.0.7-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:9694078c5d44c157ef3162e3bf3946510b857df5a3955458381d1c7cfc143ddb", size = 4892883, upload-time = "2026-04-08T01:56:32.614Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/0b/333ddab4270c4f5b972f980adef4faa66951a4aaf646ca067af597f15563/cryptography-46.0.7-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:42a1e5f98abb6391717978baf9f90dc28a743b7d9be7f0751a6f56a75d14065b", size = 4459756, upload-time = "2026-04-08T01:56:34.306Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/14/633913398b43b75f1234834170947957c6b623d1701ffc7a9600da907e89/cryptography-46.0.7-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:91bbcb08347344f810cbe49065914fe048949648f6bd5c2519f34619142bbe85", size = 4410244, upload-time = "2026-04-08T01:56:35.977Z" },
+    { url = "https://files.pythonhosted.org/packages/10/f2/19ceb3b3dc14009373432af0c13f46aa08e3ce334ec6eff13492e1812ccd/cryptography-46.0.7-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:5d1c02a14ceb9148cc7816249f64f623fbfee39e8c03b3650d842ad3f34d637e", size = 4674868, upload-time = "2026-04-08T01:56:38.034Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/bb/a5c213c19ee94b15dfccc48f363738633a493812687f5567addbcbba9f6f/cryptography-46.0.7-cp311-abi3-win32.whl", hash = "sha256:d23c8ca48e44ee015cd0a54aeccdf9f09004eba9fc96f38c911011d9ff1bd457", size = 3026504, upload-time = "2026-04-08T01:56:39.666Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/02/7788f9fefa1d060ca68717c3901ae7fffa21ee087a90b7f23c7a603c32ae/cryptography-46.0.7-cp311-abi3-win_amd64.whl", hash = "sha256:397655da831414d165029da9bc483bed2fe0e75dde6a1523ec2fe63f3c46046b", size = 3488363, upload-time = "2026-04-08T01:56:41.893Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/56/15619b210e689c5403bb0540e4cb7dbf11a6bf42e483b7644e471a2812b3/cryptography-46.0.7-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:d151173275e1728cf7839aaa80c34fe550c04ddb27b34f48c232193df8db5842", size = 7119671, upload-time = "2026-04-08T01:56:44Z" },
+    { url = "https://files.pythonhosted.org/packages/74/66/e3ce040721b0b5599e175ba91ab08884c75928fbeb74597dd10ef13505d2/cryptography-46.0.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:db0f493b9181c7820c8134437eb8b0b4792085d37dbb24da050476ccb664e59c", size = 4268551, upload-time = "2026-04-08T01:56:46.071Z" },
+    { url = "https://files.pythonhosted.org/packages/03/11/5e395f961d6868269835dee1bafec6a1ac176505a167f68b7d8818431068/cryptography-46.0.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ebd6daf519b9f189f85c479427bbd6e9c9037862cf8fe89ee35503bd209ed902", size = 4408887, upload-time = "2026-04-08T01:56:47.718Z" },
+    { url = "https://files.pythonhosted.org/packages/40/53/8ed1cf4c3b9c8e611e7122fb56f1c32d09e1fff0f1d77e78d9ff7c82653e/cryptography-46.0.7-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:b7b412817be92117ec5ed95f880defe9cf18a832e8cafacf0a22337dc1981b4d", size = 4271354, upload-time = "2026-04-08T01:56:49.312Z" },
+    { url = "https://files.pythonhosted.org/packages/50/46/cf71e26025c2e767c5609162c866a78e8a2915bbcfa408b7ca495c6140c4/cryptography-46.0.7-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:fbfd0e5f273877695cb93baf14b185f4878128b250cc9f8e617ea0c025dfb022", size = 4905845, upload-time = "2026-04-08T01:56:50.916Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/ea/01276740375bac6249d0a971ebdf6b4dc9ead0ee0a34ef3b5a88c1a9b0d4/cryptography-46.0.7-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:ffca7aa1d00cf7d6469b988c581598f2259e46215e0140af408966a24cf086ce", size = 4444641, upload-time = "2026-04-08T01:56:52.882Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/4c/7d258f169ae71230f25d9f3d06caabcff8c3baf0978e2b7d65e0acac3827/cryptography-46.0.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:60627cf07e0d9274338521205899337c5d18249db56865f943cbe753aa96f40f", size = 3967749, upload-time = "2026-04-08T01:56:54.597Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/2a/2ea0767cad19e71b3530e4cad9605d0b5e338b6a1e72c37c9c1ceb86c333/cryptography-46.0.7-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:80406c3065e2c55d7f49a9550fe0c49b3f12e5bfff5dedb727e319e1afb9bf99", size = 4270942, upload-time = "2026-04-08T01:56:56.416Z" },
+    { url = "https://files.pythonhosted.org/packages/41/3d/fe14df95a83319af25717677e956567a105bb6ab25641acaa093db79975d/cryptography-46.0.7-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:c5b1ccd1239f48b7151a65bc6dd54bcfcc15e028c8ac126d3fada09db0e07ef1", size = 4871079, upload-time = "2026-04-08T01:56:58.31Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/59/4a479e0f36f8f378d397f4eab4c850b4ffb79a2f0d58704b8fa0703ddc11/cryptography-46.0.7-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:d5f7520159cd9c2154eb61eb67548ca05c5774d39e9c2c4339fd793fe7d097b2", size = 4443999, upload-time = "2026-04-08T01:57:00.508Z" },
+    { url = "https://files.pythonhosted.org/packages/28/17/b59a741645822ec6d04732b43c5d35e4ef58be7bfa84a81e5ae6f05a1d33/cryptography-46.0.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:fcd8eac50d9138c1d7fc53a653ba60a2bee81a505f9f8850b6b2888555a45d0e", size = 4399191, upload-time = "2026-04-08T01:57:02.654Z" },
+    { url = "https://files.pythonhosted.org/packages/59/6a/bb2e166d6d0e0955f1e9ff70f10ec4b2824c9cfcdb4da772c7dd69cc7d80/cryptography-46.0.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:65814c60f8cc400c63131584e3e1fad01235edba2614b61fbfbfa954082db0ee", size = 4655782, upload-time = "2026-04-08T01:57:04.592Z" },
+    { url = "https://files.pythonhosted.org/packages/95/b6/3da51d48415bcb63b00dc17c2eff3a651b7c4fed484308d0f19b30e8cb2c/cryptography-46.0.7-cp314-cp314t-win32.whl", hash = "sha256:fdd1736fed309b4300346f88f74cd120c27c56852c3838cab416e7a166f67298", size = 3002227, upload-time = "2026-04-08T01:57:06.91Z" },
+    { url = "https://files.pythonhosted.org/packages/32/a8/9f0e4ed57ec9cebe506e58db11ae472972ecb0c659e4d52bbaee80ca340a/cryptography-46.0.7-cp314-cp314t-win_amd64.whl", hash = "sha256:e06acf3c99be55aa3b516397fe42f5855597f430add9c17fa46bf2e0fb34c9bb", size = 3475332, upload-time = "2026-04-08T01:57:08.807Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/7f/cd42fc3614386bc0c12f0cb3c4ae1fc2bbca5c9662dfed031514911d513d/cryptography-46.0.7-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:462ad5cb1c148a22b2e3bcc5ad52504dff325d17daf5df8d88c17dda1f75f2a4", size = 7165618, upload-time = "2026-04-08T01:57:10.645Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/d0/36a49f0262d2319139d2829f773f1b97ef8aef7f97e6e5bd21455e5a8fb5/cryptography-46.0.7-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:84d4cced91f0f159a7ddacad249cc077e63195c36aac40b4150e7a57e84fffe7", size = 4270628, upload-time = "2026-04-08T01:57:12.885Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/6c/1a42450f464dda6ffbe578a911f773e54dd48c10f9895a23a7e88b3e7db5/cryptography-46.0.7-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:128c5edfe5e5938b86b03941e94fac9ee793a94452ad1365c9fc3f4f62216832", size = 4415405, upload-time = "2026-04-08T01:57:14.923Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/92/4ed714dbe93a066dc1f4b4581a464d2d7dbec9046f7c8b7016f5286329e2/cryptography-46.0.7-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:5e51be372b26ef4ba3de3c167cd3d1022934bc838ae9eaad7e644986d2a3d163", size = 4272715, upload-time = "2026-04-08T01:57:16.638Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/e6/a26b84096eddd51494bba19111f8fffe976f6a09f132706f8f1bf03f51f7/cryptography-46.0.7-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:cdf1a610ef82abb396451862739e3fc93b071c844399e15b90726ef7470eeaf2", size = 4918400, upload-time = "2026-04-08T01:57:19.021Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/08/ffd537b605568a148543ac3c2b239708ae0bd635064bab41359252ef88ed/cryptography-46.0.7-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:1d25aee46d0c6f1a501adcddb2d2fee4b979381346a78558ed13e50aa8a59067", size = 4450634, upload-time = "2026-04-08T01:57:21.185Z" },
+    { url = "https://files.pythonhosted.org/packages/16/01/0cd51dd86ab5b9befe0d031e276510491976c3a80e9f6e31810cce46c4ad/cryptography-46.0.7-cp38-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:cdfbe22376065ffcf8be74dc9a909f032df19bc58a699456a21712d6e5eabfd0", size = 3985233, upload-time = "2026-04-08T01:57:22.862Z" },
+    { url = "https://files.pythonhosted.org/packages/92/49/819d6ed3a7d9349c2939f81b500a738cb733ab62fbecdbc1e38e83d45e12/cryptography-46.0.7-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:abad9dac36cbf55de6eb49badd4016806b3165d396f64925bf2999bcb67837ba", size = 4271955, upload-time = "2026-04-08T01:57:24.814Z" },
+    { url = "https://files.pythonhosted.org/packages/80/07/ad9b3c56ebb95ed2473d46df0847357e01583f4c52a85754d1a55e29e4d0/cryptography-46.0.7-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:935ce7e3cfdb53e3536119a542b839bb94ec1ad081013e9ab9b7cfd478b05006", size = 4879888, upload-time = "2026-04-08T01:57:26.88Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/c7/201d3d58f30c4c2bdbe9b03844c291feb77c20511cc3586daf7edc12a47b/cryptography-46.0.7-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:35719dc79d4730d30f1c2b6474bd6acda36ae2dfae1e3c16f2051f215df33ce0", size = 4449961, upload-time = "2026-04-08T01:57:29.068Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/ef/649750cbf96f3033c3c976e112265c33906f8e462291a33d77f90356548c/cryptography-46.0.7-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:7bbc6ccf49d05ac8f7d7b5e2e2c33830d4fe2061def88210a126d130d7f71a85", size = 4401696, upload-time = "2026-04-08T01:57:31.029Z" },
+    { url = "https://files.pythonhosted.org/packages/41/52/a8908dcb1a389a459a29008c29966c1d552588d4ae6d43f3a1a4512e0ebe/cryptography-46.0.7-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a1529d614f44b863a7b480c6d000fe93b59acee9c82ffa027cfadc77521a9f5e", size = 4664256, upload-time = "2026-04-08T01:57:33.144Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/fa/f0ab06238e899cc3fb332623f337a7364f36f4bb3f2534c2bb95a35b132c/cryptography-46.0.7-cp38-abi3-win32.whl", hash = "sha256:f247c8c1a1fb45e12586afbb436ef21ff1e80670b2861a90353d9b025583d246", size = 3013001, upload-time = "2026-04-08T01:57:34.933Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/f1/00ce3bde3ca542d1acd8f8cfa38e446840945aa6363f9b74746394b14127/cryptography-46.0.7-cp38-abi3-win_amd64.whl", hash = "sha256:506c4ff91eff4f82bdac7633318a526b1d1309fc07ca76a3ad182cb5b686d6d3", size = 3472985, upload-time = "2026-04-08T01:57:36.714Z" },
 ]
 
 [[package]]
@@ -437,6 +563,15 @@ wheels = [
 ]
 
 [[package]]
+name = "jmespath"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
+]
+
+[[package]]
 name = "jsbeautifier"
 version = "1.15.4"
 source = { registry = "https://pypi.org/simple" }
@@ -606,6 +741,32 @@ wheels = [
 ]
 
 [[package]]
+name = "moto"
+version = "5.1.22"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "boto3" },
+    { name = "botocore" },
+    { name = "cryptography" },
+    { name = "jinja2" },
+    { name = "python-dateutil" },
+    { name = "requests" },
+    { name = "responses" },
+    { name = "werkzeug" },
+    { name = "xmltodict" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b2/3d/1765accbf753dc1ae52f26a2e2ed2881d78c2eb9322c178e45312472e4a0/moto-5.1.22.tar.gz", hash = "sha256:e5b2c378296e4da50ce5a3c355a1743c8d6d396ea41122f5bb2a40f9b9a8cc0e", size = 8547792, upload-time = "2026-03-08T21:06:43.731Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/4f/8812a01e3e0bd6be3e13b90432fb5c696af9a720af3f00e6eba5ad748345/moto-5.1.22-py3-none-any.whl", hash = "sha256:d9f20ae3cf29c44f93c1f8f06c8f48d5560e5dc027816ef1d0d2059741ffcfbe", size = 6617400, upload-time = "2026-03-08T21:06:41.093Z" },
+]
+
+[package.optional-dependencies]
+s3 = [
+    { name = "py-partiql-parser" },
+    { name = "pyyaml" },
+]
+
+[[package]]
 name = "olivalle"
 version = "1.1"
 source = { virtual = "." }
@@ -625,7 +786,9 @@ dependencies = [
 
 [package.optional-dependencies]
 dev = [
+    { name = "boto3" },
     { name = "httpx" },
+    { name = "moto", extra = ["s3"] },
     { name = "pytest" },
     { name = "ruff" },
 ]
@@ -638,6 +801,7 @@ docs = [
 [package.metadata]
 requires-dist = [
     { name = "bcrypt", specifier = ">=4.2" },
+    { name = "boto3", marker = "extra == 'dev'", specifier = ">=1.34" },
     { name = "brevo-python", specifier = ">=4" },
     { name = "fastapi", specifier = ">=0.115" },
     { name = "fpdf2", specifier = ">=2.8" },
@@ -647,6 +811,7 @@ requires-dist = [
     { name = "mkdocs", marker = "extra == 'docs'", specifier = ">=1.6" },
     { name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9" },
     { name = "mkdocs-mermaid2-plugin", marker = "extra == 'docs'", specifier = ">=1" },
+    { name = "moto", extras = ["s3"], marker = "extra == 'dev'", specifier = ">=5.0" },
     { name = "pydantic-settings", specifier = ">=2.7" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8" },
     { name = "python-multipart", specifier = ">=0.0.18" },
@@ -758,6 +923,24 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "py-partiql-parser"
+version = "0.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/56/7a/a0f6bda783eb4df8e3dfd55973a1ac6d368a89178c300e1b5b91cd181e5e/py_partiql_parser-0.6.3.tar.gz", hash = "sha256:09cecf916ce6e3da2c050f0cb6106166de42c33d34a078ec2eb19377ea70389a", size = 17456, upload-time = "2025-10-18T13:56:13.441Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c9/33/a7cbfccc39056a5cf8126b7aab4c8bafbedd4f0ca68ae40ecb627a2d2cd3/py_partiql_parser-0.6.3-py2.py3-none-any.whl", hash = "sha256:deb0769c3346179d2f590dcbde556f708cdb929059fb654bad75f4cf6e07f582", size = 23752, upload-time = "2025-10-18T13:56:12.256Z" },
+]
+
+[[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
 ]
 
 [[package]]
@@ -1010,6 +1193,20 @@ wheels = [
 ]
 
 [[package]]
+name = "responses"
+version = "0.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9f/b4/b7e040379838cc71bf5aabdb26998dfbe5ee73904c92c1c161faf5de8866/responses-0.26.0.tar.gz", hash = "sha256:c7f6923e6343ef3682816ba421c006626777893cb0d5e1434f674b649bac9eb4", size = 81303, upload-time = "2026-02-19T14:38:05.574Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/04/7f73d05b556da048923e31a0cc878f03be7c5425ed1f268082255c75d872/responses-0.26.0-py3-none-any.whl", hash = "sha256:03ec4409088cd5c66b71ecbbbd27fe2c58ddfad801c66203457b3e6a04868c37", size = 35099, upload-time = "2026-02-19T14:38:03.847Z" },
+]
+
+[[package]]
 name = "ruff"
 version = "0.15.7"
 source = { registry = "https://pypi.org/simple" }
@@ -1032,6 +1229,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/26/6b/8786ba5736562220d588a2f6653e6c17e90c59ced34a2d7b512ef8956103/ruff-0.15.7-py3-none-win32.whl", hash = "sha256:6d39e2d3505b082323352f733599f28169d12e891f7dd407f2d4f54b4c2886de", size = 10582538, upload-time = "2026-03-19T16:26:15.992Z" },
     { url = "https://files.pythonhosted.org/packages/2b/e9/346d4d3fffc6871125e877dae8d9a1966b254fbd92a50f8561078b88b099/ruff-0.15.7-py3-none-win_amd64.whl", hash = "sha256:4d53d712ddebcd7dace1bc395367aec12c057aacfe9adbb6d832302575f4d3a1", size = 11755839, upload-time = "2026-03-19T16:26:19.897Z" },
     { url = "https://files.pythonhosted.org/packages/8f/e8/726643a3ea68c727da31570bde48c7a10f1aa60eddd628d94078fec586ff/ruff-0.15.7-py3-none-win_arm64.whl", hash = "sha256:18e8d73f1c3fdf27931497972250340f92e8c861722161a9caeb89a58ead6ed2", size = 11023304, upload-time = "2026-03-19T16:26:51.669Z" },
+]
+
+[[package]]
+name = "s3transfer"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/05/04/74127fc843314818edfa81b5540e26dd537353b123a4edc563109d8f17dd/s3transfer-0.16.0.tar.gz", hash = "sha256:8e990f13268025792229cd52fa10cb7163744bf56e719e0b9cb925ab79abf920", size = 153827, upload-time = "2025-12-01T02:30:59.114Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/51/727abb13f44c1fcf6d145979e1535a35794db0f6e450a0cb46aa24732fe2/s3transfer-0.16.0-py3-none-any.whl", hash = "sha256:18e25d66fed509e3868dc1572b3f427ff947dd2c56f844a5bf09481ad3f3b2fe", size = 86830, upload-time = "2025-12-01T02:30:57.729Z" },
 ]
 
 [[package]]
@@ -1287,4 +1496,25 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/b6/b9afed2afadddaf5ebb2afa801abf4b0868f42f8539bfe4b071b5266c9fe/websockets-16.0-cp314-cp314t-win32.whl", hash = "sha256:5a4b4cc550cb665dd8a47f868c8d04c8230f857363ad3c9caf7a0c3bf8c61ca6", size = 178085, upload-time = "2026-01-10T09:23:33.816Z" },
     { url = "https://files.pythonhosted.org/packages/9f/3e/28135a24e384493fa804216b79a6a6759a38cc4ff59118787b9fb693df93/websockets-16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b14dc141ed6d2dde437cddb216004bcac6a1df0935d79656387bd41632ba0bbd", size = 178531, upload-time = "2026-01-10T09:23:35.016Z" },
     { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
+]
+
+[[package]]
+name = "werkzeug"
+version = "3.1.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dd/b2/381be8cfdee792dd117872481b6e378f85c957dd7c5bca38897b08f765fd/werkzeug-3.1.8.tar.gz", hash = "sha256:9bad61a4268dac112f1c5cd4630a56ede601b6ed420300677a869083d70a4c44", size = 875852, upload-time = "2026-04-02T18:49:14.268Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/8c/2e650f2afeb7ee576912636c23ddb621c91ac6a98e66dc8d29c3c69446e1/werkzeug-3.1.8-py3-none-any.whl", hash = "sha256:63a77fb8892bf28ebc3178683445222aa500e48ebad5ec77b0ad80f8726b1f50", size = 226459, upload-time = "2026-04-02T18:49:12.72Z" },
+]
+
+[[package]]
+name = "xmltodict"
+version = "1.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/70/80f3b7c10d2630aa66414bf23d210386700aa390547278c789afa994fd7e/xmltodict-1.0.4.tar.gz", hash = "sha256:6d94c9f834dd9e44514162799d344d815a3a4faec913717a9ecbfa5be1bb8e61", size = 26124, upload-time = "2026-02-22T02:21:22.074Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/34/98a2f52245f4d47be93b580dae5f9861ef58977d73a79eb47c58f1ad1f3a/xmltodict-1.0.4-py3-none-any.whl", hash = "sha256:a4a00d300b0e1c59fc2bfccb53d7b2e88c32f200df138a0dd2229f842497026a", size = 13580, upload-time = "2026-02-22T02:21:21.039Z" },
 ]


### PR DESCRIPTION
## Summary

- Neue scheduled GitHub Action `backup-check.yml` prüft täglich (05:17 UTC) via S3-API bei Tigris, ob das neueste Objekt im Bucket `olivalle-backup` < 24 h alt ist. Bei OK → Ping an Healthchecks.io, sonst silent skip. Grace 25 h alarmiert per E-Mail.
- Heartbeat-Loop aus `entrypoint.sh` ersatzlos entfernt — hatte Pfad-Bug (`.olivalle.db-litestream` vs `olivalle.db-litestream`) und mass am falschen Ende (Server-Zwischenschritt statt Cloud-Ergebnis).
- Doku: ADR-Nachtrag 2026-04-22b, Runbook-Abschnitt "Backup-Monitoring-Alarm erhalten" (ersetzt "Heartbeat-Alert"), README-Zeile ergänzt.
- CI: `scripts/` wird jetzt ebenfalls von Ruff gelintet.

**Spec:** `docs/superpowers/specs/2026-04-22-issue-118-backup-monitoring-design.md`
**Plan:** `docs/superpowers/plans/2026-04-22-issue-118-backup-monitoring.md`

## Test plan (Ops-Steps vor Merge — manuell durch Entwickler)

- [x] `uv run pytest tests/test_check_backup.py -v` → 4 PASSED
- [x] `uv run ruff check app tests scripts` → clean
- [x] `uv run pytest` → 212 PASSED
- [ ] GitHub Repo-Secrets setzen (siehe unten)
- [ ] `gh workflow run backup-check.yml --ref feat/118-external-backup-monitoring` → Log zeigt `ok, ping sent`
- [ ] Healthchecks.io-Check umkonfigurieren: Period `1 day`, Grace `25h`, unpausen
- [ ] Merge + Deploy
- [ ] `fly secrets unset HEALTHCHECKS_URL -a olivalle`
- [ ] 7 Tage Beobachtung ohne false-positives

### GitHub Repo-Secrets (aus fly-Secrets übernehmen)

```bash
fly ssh console -a olivalle -C 'printenv LITESTREAM_ACCESS_KEY_ID'
fly ssh console -a olivalle -C 'printenv LITESTREAM_SECRET_ACCESS_KEY'
fly ssh console -a olivalle -C 'printenv HEALTHCHECKS_URL'
```

Werte via Settings → Secrets and variables → Actions als drei Secrets eintragen:
- `LITESTREAM_ACCESS_KEY_ID`
- `LITESTREAM_SECRET_ACCESS_KEY`
- `HEALTHCHECKS_URL`

## Design-Tradeoffs

- **D4 Silent Skip** (bewusst): Bei Tigris-API-Fehler kein Alarm. Healthchecks.io alarmiert nach 25h Grace falls Problem anhält. Verzögert den Alarm bei mehrtägigem Tigris-Ausfall auf ~48h — für Olivalle-Scale akzeptabel.
- **D2 Credential-Reuse**: Bestehende `LITESTREAM_*`-Keys werden wiederverwendet (read-only via `ListObjectsV2`). Separate RO-Keys verworfen wegen Single-Dev-Aufwand.
- **Testing via MagicMock** statt moto: moto interceptet S3-Calls mit custom `endpoint_url` (Tigris) nicht — MagicMock auf `boto3.client` ist robuster und idiomatischer.

Closes #118