### PR TITLE
docs: Hinweis auf --build-arg APP_VERSION bei manuellem fly deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,10 +119,12 @@ Einstiegspunkt: [**docs/index.md**](docs/index.md)
 Produktionsdeployment läuft über GitHub Actions nach `fly.io`:
 
 ```bash
-fly deploy                    # manueller Deploy vom lokalen Rechner
-fly logs                      # Live-Logs der Produktions-App
-fly ssh console               # Shell in den Container
+fly deploy --build-arg APP_VERSION=vX.Y.Z   # manueller Deploy (ARG nötig, sonst Footer zeigt "dev")
+fly logs                                    # Live-Logs der Produktions-App
+fly ssh console                             # Shell in den Container
 ```
+
+Produktiv bevorzugt via CI (Push auf `main`) deployen — die Version (`APP_VERSION`) wird dort automatisch aus `pyproject.toml` + Tag-Count berechnet und als Docker-Build-Arg gesetzt.
 
 Konfiguration: [`fly.toml`](fly.toml). Persistente Daten (SQLite-DB) liegen auf dem Volume `olivalle_data` unter `/data`.
 


### PR DESCRIPTION
## Summary
- README-Deployment-Abschnitt präzisiert: manueller `fly deploy` braucht `--build-arg APP_VERSION=vX.Y.Z`, sonst fällt die Version auf Dockerfile-Default "dev" zurück und der Footer zeigt "dev" statt `vX.Y.Z`.
- CI-Deploy (Push auf `main`) explizit als bevorzugter Weg markiert.

## Hintergrund
Am 2026-04-22 zeigte der Live-Footer "dev" statt `v1.1.10`, weil während #118 (Monitoring-Umbau) mehrere manuelle `flyctl deploy`-Releases (v112–v114) ohne Build-Arg gelaufen waren. Der folgende CI-Deploy (v115) hat die Anzeige automatisch repariert. Der Doku-Hinweis verhindert Wiederholung.

## Test plan
- [x] Diff enthält nur README.md
- [x] Keine Code-Änderungen, keine Tests betroffen
- [ ] CI-Lint grün

🤖 Generated with [Claude Code](https://claude.com/claude-code)