### PR TITLE
docs: Restore-Test v2 protokolliert (#123)

### DIFF
--- a/docs/runbook-restore.md
+++ b/docs/runbook-restore.md
@@ -166,4 +166,18 @@ nicht erreichen.
 
 | Datum | Ergebnis `integrity_check` | Bestellungen | Bemerkung |
 |---|---|---|---|
-| YYYY-MM-DD | ok / FAIL | N | — |
+| 2026-04-23 | FAIL → ok (Rollback) | 33 | Erster Versuch (#115): Race-Condition zwischen `mv` und `fly machine restart` — silent leere DB angelegt. Rollback via `.sim-backup` → 33 Bestellungen sauber zurück. |
+| 2026-04-23 | ok | 33 | Restore-Test v2 (#123): destruktiver End-to-End-Test nach App-Safeguard (#122). DB-Grösse, COUNT, MIN/MAX `erstellt_am` identisch zum Pre-Test-Snapshot. Downtime ~4 min. |
+
+### Lektion aus Test v2 (#123): `kill 1` via `fly ssh console -C` funktioniert nicht
+
+Der atomische Trigger `fly ssh console -a olivalle -C "sh -c 'mv /data/olivalle.db /data/olivalle.db.sim-backup && sync && kill 1'"` killt **nicht** den Container-Main-Prozess — die SSH-Session läuft in einem eigenen PID-Namespace (wahrscheinlich fly-sshd). Litestream + uvicorn liefen nach dem `kill` unverändert weiter; nur die DB war weg → App warf HTTP 500 (dank Safeguard #122), aber kein Auto-Restore wurde getriggert.
+
+**Sichere Sequenz für zukünftige destruktive Tests:**
+
+```bash
+fly ssh console -a olivalle -C "mv /data/olivalle.db /data/olivalle.db.sim-backup"
+fly machine restart -a olivalle   # erzwingt entrypoint.sh neu → Auto-Restore aus Tigris
+```
+
+Zwischen `mv` und `fly machine restart` sieht die laufende App die fehlende DB → HTTP 500 (#122) → **kein** silent empty DB. Race-Condition ist durch das Safeguard konstruktiv ausgeschlossen, auch wenn zwischen den beiden Befehlen mehrere Sekunden liegen.


### PR DESCRIPTION
## Summary

- Protokoll-Zeilen für beide Restore-Tests vom 2026-04-23 im Runbook ergänzt (erster Versuch #115 = fail→rollback; zweiter Versuch #123 = ok).
- Lektion dokumentiert: `kill 1` über `fly ssh console -C` funktioniert nicht — SSH läuft in einem eigenen PID-Namespace. Sichere Sequenz für zukünftige destruktive Tests: `mv` via ssh, danach `fly machine restart`. Race-Condition ist durch den Safeguard aus #122 konstruktiv ausgeschlossen.

Schliesst: #123 (und #115, da inhaltlich abgedeckt durch v2)

## Test plan

- [x] Pre-Test-Snapshot genommen (33 Bestellungen, 77824 B)
- [x] Destruktiver Test via `fly machine restart` (kill-1-Variante schlug fehl, Fallback B aus Runbook griff)
- [x] Post-Test: DB-Grösse, COUNT, MIN/MAX `erstellt_am` exakt identisch
- [x] `PRAGMA integrity_check` = ok
- [x] Shop HTTP 200
- [x] Admin-Bereich vom SH verifiziert (letzte 5 Bestellungen passen)

## Offene Nachbereitung (nach Merge, separat)

- Volume-Cleanup: `/data/olivalle.db.sim-backup` und `/data/olivalle.db.restore-fail` löschen
- Issues #115 und #123 schliessen mit Resultat-Kommentar
- Kalendereintrag für Jahres-Restore-Test (2027-04-23) setzen

🤖 Generated with [Claude Code](https://claude.com/claude-code)
