### PR TITLE
ops: fly-internen Healthcheck auf /health (#111)

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -22,6 +22,13 @@ primary_region = 'cdg'
   auto_start_machines = true
   min_machines_running = 1
 
+[[http_service.checks]]
+  interval = "30s"
+  timeout = "5s"
+  grace_period = "10s"
+  method = "GET"
+  path = "/health"
+
 [[vm]]
   memory = '256mb'
   cpu_kind = 'shared'


### PR DESCRIPTION
Teil 2 von Issue #111 (Uptime- + TLS-Monitoring).

Ergänzt fly.toml um einen \`[[http_service.checks]]\`-Block. fly.io pollt dann intern alle 30s \`GET /health\` (timeout 5s, grace 10s). Bei 3 aufeinanderfolgenden Fehlern restartet fly die Machine automatisch.

## Zusammenspiel mit PR #126
PR #126 hat \`/health\` um einen DB-Touch erweitert (503 bei SQLite-Fehler). Dieser Check greift jetzt: Fällt die DB weg, meldet \`/health\` 503, fly-Proxy erkennt das, nach 3 Fehlern (~90s) startet die Machine neu. entrypoint.sh versucht beim Boot Auto-Restore aus Litestream (#118).

## Verifikation nach Deploy
Wird nach Merge manuell geprüft via \`fly checks list -a olivalle\` — Eintrag für /health muss \"passing\" zeigen.

## Nächste PRs
- PR 3: GitHub Actions \`monitor-uptime.yml\` + \`monitor-tls.yml\` + \`scripts/check_tls.py\` (nach manuellen Setup-Schritten: Healthchecks.io + GitHub-Secrets)
- PR 4: Runbook \`docs/runbook-incident.md\`

Refs #111