### PR TITLE
feat: HTTP- und TLS-Monitoring via GitHub Actions (#111)

### DIFF
--- a/.github/workflows/monitor-tls.yml
+++ b/.github/workflows/monitor-tls.yml
@@ -1,0 +1,32 @@
+name: TLS-Monitor
+
+on:
+  schedule:
+    - cron: '23 5 * * *'
+  workflow_dispatch:
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: Prüft TLS-Cert-Restlaufzeit von olivalle.ch
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
+        with:
+          python-version: "3.13"
+
+      - name: Install dependencies
+        run: uv sync --extra dev
+
+      - name: Check TLS cert freshness
+        run: uv run python scripts/check_tls.py
+        env:
+          HEALTHCHECKS_URL_TLS: ${{ secrets.HC_PING_URL_TLS }}

--- a/.github/workflows/monitor-uptime.yml
+++ b/.github/workflows/monitor-uptime.yml
@@ -1,0 +1,28 @@
+name: Uptime-Monitor
+
+on:
+  schedule:
+    - cron: '*/10 * * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: monitor-uptime
+  cancel-in-progress: false
+
+jobs:
+  check:
+    name: Prüft HTTP-Erreichbarkeit von olivalle.ch
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - name: Probe /health
+        run: curl --fail --max-time 10 https://olivalle.ch/health
+
+      - name: Ping Healthchecks.io
+        if: success()
+        run: curl --fail --max-time 10 "${HC_URL}"
+        env:
+          HC_URL: ${{ secrets.HC_PING_URL_HTTP }}

--- a/scripts/check_tls.py
+++ b/scripts/check_tls.py
@@ -1,0 +1,53 @@
+"""TLS-Cert-Monitoring für olivalle.ch (Issue #111).
+
+Prüft die Restlaufzeit des TLS-Zertifikats und pingt Healthchecks.io
+bei mindestens `THRESHOLD_DAYS` Tagen Restlaufzeit. Bei Unterschreitung
+wird kein Ping abgesetzt — Healthchecks.io alarmiert dann nach Ablauf
+der Grace-Period per E-Mail.
+"""
+
+import os
+import socket
+import ssl
+import sys
+from datetime import UTC, datetime
+from urllib.request import urlopen
+
+HOST = "olivalle.ch"
+PORT = 443
+THRESHOLD_DAYS = 30
+
+
+def _get_cert(host: str, port: int) -> dict:
+    """TLS-Handshake + Peer-Cert holen. Isoliert für Test-Mocking."""
+    ctx = ssl.create_default_context()
+    with (
+        socket.create_connection((host, port), timeout=10) as sock,
+        ctx.wrap_socket(sock, server_hostname=host) as ssock,
+    ):
+        return ssock.getpeercert()
+
+
+def _days_until_expiry(cert: dict) -> int:
+    not_after = datetime.strptime(cert["notAfter"], "%b %d %H:%M:%S %Y %Z").replace(
+        tzinfo=UTC
+    )
+    return (not_after - datetime.now(UTC)).days
+
+
+def main() -> int:
+    cert = _get_cert(HOST, PORT)
+    days_left = _days_until_expiry(cert)
+    print(f"TLS cert for {HOST}: {days_left} days left (threshold: {THRESHOLD_DAYS})")
+
+    if days_left < THRESHOLD_DAYS:
+        return 1
+
+    ping_url = os.environ["HEALTHCHECKS_URL_TLS"]
+    with urlopen(ping_url, timeout=10) as resp:
+        print(f"Healthchecks.io ping: {resp.status}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_check_tls.py
+++ b/tests/test_check_tls.py
@@ -1,0 +1,60 @@
+"""Tests für scripts/check_tls.py (Issue #111)."""
+
+import os
+import sys
+from datetime import UTC, datetime, timedelta
+from unittest.mock import patch
+
+import pytest
+
+# scripts/ auf sys.path, damit `import check_tls` funktioniert
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+
+
+def _fake_cert_with_notafter(days_from_now: int) -> dict:
+    """Baut ein cert-Dict im Format zurück, wie ssock.getpeercert() es liefert."""
+    not_after = datetime.now(UTC) + timedelta(days=days_from_now)
+    return {"notAfter": not_after.strftime("%b %d %H:%M:%S %Y GMT")}
+
+
+@pytest.fixture
+def env(monkeypatch):
+    monkeypatch.setenv("HEALTHCHECKS_URL_TLS", "https://hc-ping.example/tls-uuid")
+
+
+def test_cert_frisch_triggert_ping(env):
+    import check_tls
+
+    with (
+        patch("check_tls._get_cert", return_value=_fake_cert_with_notafter(60)),
+        patch("check_tls.urlopen") as mock_urlopen,
+    ):
+        exit_code = check_tls.main()
+
+    assert exit_code == 0
+    mock_urlopen.assert_called_once()
+    url = mock_urlopen.call_args[0][0]
+    assert url == "https://hc-ping.example/tls-uuid"
+
+
+def test_cert_laeuft_bald_ab_kein_ping(env):
+    import check_tls
+
+    with (
+        patch("check_tls._get_cert", return_value=_fake_cert_with_notafter(10)),
+        patch("check_tls.urlopen") as mock_urlopen,
+    ):
+        exit_code = check_tls.main()
+
+    assert exit_code == 1
+    mock_urlopen.assert_not_called()
+
+
+def test_cert_mit_malformed_date_wirft_klar(env):
+    import check_tls
+
+    with (
+        patch("check_tls._get_cert", return_value={"notAfter": "not-a-date"}),
+        pytest.raises(ValueError),
+    ):
+        check_tls.main()


### PR DESCRIPTION
## Summary
- Teil 3 von #111.
- Neues Python-Skript `scripts/check_tls.py` + 3 Tests (TDD, Pattern aus #118).
- Workflow `monitor-uptime.yml` (alle 10 min, `curl --fail /health` → Ping HC_PING_URL_HTTP).
- Workflow `monitor-tls.yml` (täglich, ruft `check_tls.py` → Ping HC_PING_URL_TLS bei Restlaufzeit >= 30 Tagen).

## Voraussetzungen (manuell erfüllt)
- Healthchecks.io-Checks `olivalle-http-uptime` und `olivalle-tls-expiry` existieren.
- Repo-Secrets `HC_PING_URL_HTTP` und `HC_PING_URL_TLS` sind gesetzt.

## Test plan
- [x] `uv run pytest -x` (218 grün lokal)
- [x] `uv run ruff check app tests scripts` grün
- [ ] CI: lint-Workflow grün
- [ ] Nach Merge: `gh workflow run monitor-uptime.yml` + `gh workflow run monitor-tls.yml` -> beide pingen HC erfolgreich

Spec: `docs/superpowers/specs/2026-04-23-issue-111-monitoring-design.md`
Plan: `docs/superpowers/plans/2026-04-23-issue-111-monitoring.md`

Generated with [Claude Code](https://claude.com/claude-code)
