### PR TITLE
feat: Produktbezogene Aktionspreise + Seed-Persistenz-Fix (#134, #137)

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"6c3008db-a29d-41c7-81df-57f8d2a57826","pid":31638,"procStart":"Wed May  6 06:05:35 2026","acquiredAt":1778049419408}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"6c3008db-a29d-41c7-81df-57f8d2a57826","pid":31638,"procStart":"Wed May  6 06:05:35 2026","acquiredAt":1778049419408}

--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,7 @@ site/
 .grepai/
 .superpowers/
 .worktrees/
+
+# Claude Code lokale/transiente Artefakte
+.claude/scheduled_tasks.lock
+.claude/settings.local.json

--- a/app/database.py
+++ b/app/database.py
@@ -66,6 +66,10 @@ def init_db() -> None:
             "hausnummer",
             "TEXT NOT NULL DEFAULT ''",
         )
+        _add_column_if_not_exists(conn, "produkte", "aktionspreis_chf", "REAL")
+        _add_column_if_not_exists(conn, "produkte", "aktionstext", "TEXT")
+        _add_column_if_not_exists(conn, "produkte", "aktion_von", "TEXT")
+        _add_column_if_not_exists(conn, "produkte", "aktion_bis", "TEXT")
         conn.commit()
     finally:
         conn.close()

--- a/app/main.py
+++ b/app/main.py
@@ -38,6 +38,7 @@ def health():
 from app.routers import (  # noqa: E402
     admin,
     bestellungen,
+    produkt_admin,
     produkte,
     rabattcodes,
     seiten,
@@ -52,3 +53,4 @@ app.include_router(bestellungen.router)
 app.include_router(webhooks.router)
 app.include_router(seiten.router)
 app.include_router(rabattcodes.router)
+app.include_router(produkt_admin.router)

--- a/app/models.py
+++ b/app/models.py
@@ -9,6 +9,10 @@ class Produkt(BaseModel):
     beschreibung: str
     bild_pfad: str
     aktiv: bool = True
+    aktionspreis_chf: float | None = None
+    aktionstext: str | None = None
+    aktion_von: str | None = None
+    aktion_bis: str | None = None
 
 
 class KundeInput(BaseModel):

--- a/app/repositories/produkt_repo.py
+++ b/app/repositories/produkt_repo.py
@@ -5,7 +5,8 @@ from app.models import Produkt
 
 def get_alle_produkte(conn: sqlite3.Connection) -> list[Produkt]:
     rows = conn.execute(
-        "SELECT id, name, menge_ml, preis_chf, beschreibung, bild_pfad, aktiv "
+        "SELECT id, name, menge_ml, preis_chf, beschreibung, bild_pfad, aktiv, "
+        "aktionspreis_chf, aktionstext, aktion_von, aktion_bis "
         "FROM produkte WHERE aktiv = 1 ORDER BY menge_ml"
     ).fetchall()
     return [Produkt(**dict(row)) for row in rows]

--- a/app/repositories/produkt_repo.py
+++ b/app/repositories/produkt_repo.py
@@ -10,3 +10,54 @@ def get_alle_produkte(conn: sqlite3.Connection) -> list[Produkt]:
         "FROM produkte WHERE aktiv = 1 ORDER BY menge_ml"
     ).fetchall()
     return [Produkt(**dict(row)) for row in rows]
+
+
+def alle_produkte_admin(conn: sqlite3.Connection) -> list[dict]:
+    rows = conn.execute(
+        "SELECT id, name, menge_ml, preis_chf, beschreibung, bild_pfad, aktiv, "
+        "aktionspreis_chf, aktionstext, aktion_von, aktion_bis "
+        "FROM produkte ORDER BY menge_ml"
+    ).fetchall()
+    return [dict(row) for row in rows]
+
+
+def produkt_laden(conn: sqlite3.Connection, produkt_id: int) -> dict | None:
+    row = conn.execute(
+        "SELECT id, name, menge_ml, preis_chf, beschreibung, bild_pfad, aktiv, "
+        "aktionspreis_chf, aktionstext, aktion_von, aktion_bis "
+        "FROM produkte WHERE id = ?",
+        (produkt_id,),
+    ).fetchone()
+    return dict(row) if row else None
+
+
+def aktion_setzen(
+    conn: sqlite3.Connection,
+    produkt_id: int,
+    *,
+    aktionspreis_chf: float,
+    aktionstext: str,
+    aktion_von: str | None,
+    aktion_bis: str | None,
+) -> None:
+    conn.execute(
+        "UPDATE produkte SET aktionspreis_chf = ?, aktionstext = ?, "
+        "aktion_von = ?, aktion_bis = ? WHERE id = ?",
+        (
+            aktionspreis_chf,
+            aktionstext,
+            aktion_von or None,
+            aktion_bis or None,
+            produkt_id,
+        ),
+    )
+    conn.commit()
+
+
+def aktion_entfernen(conn: sqlite3.Connection, produkt_id: int) -> None:
+    conn.execute(
+        "UPDATE produkte SET aktionspreis_chf = NULL, aktionstext = NULL, "
+        "aktion_von = NULL, aktion_bis = NULL WHERE id = ?",
+        (produkt_id,),
+    )
+    conn.commit()

--- a/app/routers/bestellungen.py
+++ b/app/routers/bestellungen.py
@@ -15,7 +15,11 @@ from app.repositories.bestell_repo import (
     kunde_anlegen,
     produktnamen_anreichern,
 )
-from app.services.bestell_service import berechne_total, berechne_versandkosten
+from app.services.bestell_service import (
+    berechne_total,
+    berechne_versandkosten,
+    rabattfaehiger_subtotal,
+)
 from app.services.email_service import (
     sende_bestellbestaetigung,
     sende_stakeholder_benachrichtigung,
@@ -164,13 +168,18 @@ def bestellen(
         # Preise serverseitig validieren
         total, positionen = berechne_total(conn, items)
 
-        # Rabattcode pruefen und anwenden
+        # Rabattcode pruefen — gilt nur auf Nicht-Aktions-Anteil
         rabattcode_id = None
         rabattbetrag = 0.0
         if rabattcode:
             from app.services.rabattcode_service import pruefe_rabattcode
 
-            rc_result = pruefe_rabattcode(conn, rabattcode, email, total)
+            rabattbasis = rabattfaehiger_subtotal(positionen)
+            if rabattbasis <= 0:
+                raise ValueError(
+                    "Auf Aktionsprodukte ist kein zusätzlicher Rabattcode möglich."
+                )
+            rc_result = pruefe_rabattcode(conn, rabattcode, email, rabattbasis)
             if rc_result["gueltig"]:
                 rabattcode_id = rc_result["rabattcode_id"]
                 rabattbetrag = rc_result["rabattbetrag"]

--- a/app/routers/produkt_admin.py
+++ b/app/routers/produkt_admin.py
@@ -99,7 +99,10 @@ def admin_aktion_speichern(
                 details=produkt["name"],
             )
         else:
-            preis = float(aktionspreis_chf)
+            try:
+                preis = float(aktionspreis_chf)
+            except ValueError:
+                raise HTTPException(400, "Ungültiger Aktionspreis.") from None
             if preis <= 0 or preis >= produkt["preis_chf"]:
                 raise HTTPException(
                     400, "Aktionspreis muss grösser als 0 und kleiner als der "

--- a/app/routers/produkt_admin.py
+++ b/app/routers/produkt_admin.py
@@ -1,0 +1,121 @@
+from fastapi import APIRouter, Cookie, Depends, Form, HTTPException, Request
+from fastapi.responses import RedirectResponse
+
+from app.config import settings
+from app.csrf import admin_identity, generiere_csrf_token, require_csrf
+from app.database import get_db
+from app.repositories.admin_repo import log_eintrag_schreiben
+from app.repositories.produkt_repo import (
+    aktion_entfernen,
+    aktion_setzen,
+    alle_produkte_admin,
+    produkt_laden,
+)
+from app.services.auth_service import validate_session
+from app.templating import templates
+
+router = APIRouter()
+
+
+def _get_admin_label(admin_session: str | None) -> str | None:
+    if not admin_session:
+        return None
+    return validate_session(
+        admin_session,
+        secret=settings.secret_key,
+        max_age=settings.admin_session_max_age,
+    )
+
+
+@router.get("/admin/produkte")
+def admin_produkte_liste(request: Request, admin_session: str | None = Cookie(None)):
+    label = _get_admin_label(admin_session)
+    if not label:
+        return RedirectResponse("/admin/login", status_code=303)
+    conn = get_db()
+    try:
+        produkte = alle_produkte_admin(conn)
+    finally:
+        conn.close()
+    csrf = generiere_csrf_token(
+        settings.secret_key, identity=admin_identity(admin_session or "")
+    )
+    return templates.TemplateResponse(
+        request,
+        "admin/produkte.html",
+        {"admin_label": label, "csrf_token": csrf, "produkte": produkte},
+    )
+
+
+@router.get("/admin/produkte/{produkt_id}/aktion")
+def admin_aktion_formular(
+    request: Request, produkt_id: int, admin_session: str | None = Cookie(None)
+):
+    label = _get_admin_label(admin_session)
+    if not label:
+        return RedirectResponse("/admin/login", status_code=303)
+    conn = get_db()
+    try:
+        produkt = produkt_laden(conn, produkt_id)
+    finally:
+        conn.close()
+    if not produkt:
+        return RedirectResponse("/admin/produkte", status_code=303)
+    csrf = generiere_csrf_token(
+        settings.secret_key, identity=admin_identity(admin_session or "")
+    )
+    return templates.TemplateResponse(
+        request,
+        "admin/produkt_aktion_form.html",
+        {"admin_label": label, "csrf_token": csrf, "produkt": produkt},
+    )
+
+
+@router.post(
+    "/admin/produkte/{produkt_id}/aktion", dependencies=[Depends(require_csrf)]
+)
+def admin_aktion_speichern(
+    request: Request,
+    produkt_id: int,
+    aktionspreis_chf: str = Form(""),
+    aktionstext: str = Form(""),
+    aktion_von: str = Form(""),
+    aktion_bis: str = Form(""),
+    csrf_token: str = Form(""),
+    admin_session: str | None = Cookie(None),
+):
+    label = _get_admin_label(admin_session)
+    if not label:
+        return RedirectResponse("/admin/login", status_code=303)
+    conn = get_db()
+    try:
+        produkt = produkt_laden(conn, produkt_id)
+        if not produkt:
+            raise HTTPException(404, "Produkt nicht gefunden")
+        if not aktionspreis_chf.strip():
+            aktion_entfernen(conn, produkt_id)
+            log_eintrag_schreiben(
+                conn, admin_label=label, aktion="aktion_entfernt",
+                details=produkt["name"],
+            )
+        else:
+            preis = float(aktionspreis_chf)
+            if preis <= 0 or preis >= produkt["preis_chf"]:
+                raise HTTPException(
+                    400, "Aktionspreis muss grösser als 0 und kleiner als der "
+                    "Normalpreis sein.",
+                )
+            aktion_setzen(
+                conn, produkt_id,
+                aktionspreis_chf=preis,
+                aktionstext=aktionstext.strip(),
+                aktion_von=aktion_von.strip() or None,
+                aktion_bis=aktion_bis.strip() or None,
+            )
+            log_eintrag_schreiben(
+                conn, admin_label=label, aktion="aktion_gesetzt",
+                details=f"{produkt['name']}: CHF {preis:.2f}",
+            )
+    finally:
+        conn.close()
+    return RedirectResponse("/admin/produkte", status_code=303)

--- a/app/routers/produkt_admin.py
+++ b/app/routers/produkt_admin.py
@@ -1,3 +1,5 @@
+from datetime import date
+
 from fastapi import APIRouter, Cookie, Depends, Form, HTTPException, Request
 from fastapi.responses import RedirectResponse
 
@@ -95,7 +97,9 @@ def admin_aktion_speichern(
         if not aktionspreis_chf.strip():
             aktion_entfernen(conn, produkt_id)
             log_eintrag_schreiben(
-                conn, admin_label=label, aktion="aktion_entfernt",
+                conn,
+                admin_label=label,
+                aktion="aktion_entfernt",
                 details=produkt["name"],
             )
         else:
@@ -105,18 +109,38 @@ def admin_aktion_speichern(
                 raise HTTPException(400, "Ungültiger Aktionspreis.") from None
             if preis <= 0 or preis >= produkt["preis_chf"]:
                 raise HTTPException(
-                    400, "Aktionspreis muss grösser als 0 und kleiner als der "
+                    400,
+                    "Aktionspreis muss grösser als 0 und kleiner als der "
                     "Normalpreis sein.",
                 )
+            # F3 — validate ISO date format for non-empty date fields
+            von = aktion_von.strip()
+            bis = aktion_bis.strip()
+            for feldwert in (von, bis):
+                if feldwert:
+                    try:
+                        date.fromisoformat(feldwert)
+                    except ValueError:
+                        raise HTTPException(
+                            400, "Ungültiges Datumsformat."
+                        ) from None
+            # F2 — reject inverted date range
+            if von and bis and von > bis:
+                raise HTTPException(
+                    400, "Aktions-Enddatum liegt vor dem Startdatum."
+                )
             aktion_setzen(
-                conn, produkt_id,
+                conn,
+                produkt_id,
                 aktionspreis_chf=preis,
                 aktionstext=aktionstext.strip(),
-                aktion_von=aktion_von.strip() or None,
-                aktion_bis=aktion_bis.strip() or None,
+                aktion_von=von or None,
+                aktion_bis=bis or None,
             )
             log_eintrag_schreiben(
-                conn, admin_label=label, aktion="aktion_gesetzt",
+                conn,
+                admin_label=label,
+                aktion="aktion_gesetzt",
                 details=f"{produkt['name']}: CHF {preis:.2f}",
             )
     finally:

--- a/app/routers/produkt_admin.py
+++ b/app/routers/produkt_admin.py
@@ -121,14 +121,10 @@ def admin_aktion_speichern(
                     try:
                         date.fromisoformat(feldwert)
                     except ValueError:
-                        raise HTTPException(
-                            400, "Ungültiges Datumsformat."
-                        ) from None
+                        raise HTTPException(400, "Ungültiges Datumsformat.") from None
             # F2 — reject inverted date range
             if von and bis and von > bis:
-                raise HTTPException(
-                    400, "Aktions-Enddatum liegt vor dem Startdatum."
-                )
+                raise HTTPException(400, "Aktions-Enddatum liegt vor dem Startdatum.")
             aktion_setzen(
                 conn,
                 produkt_id,

--- a/app/routers/produkte.py
+++ b/app/routers/produkte.py
@@ -1,7 +1,10 @@
+from datetime import date
+
 from fastapi import APIRouter, Request
 
 from app.database import get_db
 from app.repositories.produkt_repo import get_alle_produkte
+from app.services.aktions_service import effektiver_preis
 from app.templating import templates
 
 router = APIRouter()
@@ -14,6 +17,25 @@ def startseite(request: Request):
         produkte = get_alle_produkte(conn)
     finally:
         conn.close()
+    heute = date.today()
+    ansichten = []
+    for p in produkte:
+        ep = effektiver_preis(
+            p.preis_chf, p.aktionspreis_chf, p.aktion_von, p.aktion_bis, heute
+        )
+        ansichten.append(
+            {
+                "id": p.id,
+                "name": p.name,
+                "beschreibung": p.beschreibung,
+                "bild_pfad": p.bild_pfad,
+                "preis": ep.preis,
+                "ist_aktion": ep.ist_aktion,
+                "original_preis": ep.original_preis,
+                "prozent": ep.prozent,
+                "aktionstext": p.aktionstext,
+            }
+        )
     return templates.TemplateResponse(
-        request, "produkte.html", {"produkte": produkte, "active_page": "produkte"}
+        request, "produkte.html", {"produkte": ansichten, "active_page": "produkte"}
     )

--- a/app/services/aktions_service.py
+++ b/app/services/aktions_service.py
@@ -1,0 +1,55 @@
+"""Zentrale Logik für produktbezogene Aktionspreise (Issue #134).
+
+Einzige Stelle, die entscheidet, ob und welcher Aktionspreis zu einem
+gegebenen Datum gilt. Rein funktional, ohne DB-Zugriff.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import NamedTuple
+
+
+class EffektivPreis(NamedTuple):
+    preis: float
+    ist_aktion: bool
+    original_preis: float
+    prozent: int
+
+
+def _aktion_aktiv(
+    aktionspreis_chf: float | None,
+    aktion_von: str | None,
+    aktion_bis: str | None,
+    heute: date,
+) -> bool:
+    if aktionspreis_chf is None:
+        return False
+    h = heute.isoformat()
+    if aktion_von and h < aktion_von:
+        return False
+    return not (aktion_bis and h > aktion_bis)
+
+
+def effektiver_preis(
+    preis_chf: float,
+    aktionspreis_chf: float | None,
+    aktion_von: str | None,
+    aktion_bis: str | None,
+    heute: date,
+) -> EffektivPreis:
+    """Liefert den gültigen Preis samt Aktions-Metadaten für ein Datum."""
+    if _aktion_aktiv(aktionspreis_chf, aktion_von, aktion_bis, heute):
+        prozent = round((1 - aktionspreis_chf / preis_chf) * 100)
+        return EffektivPreis(
+            preis=aktionspreis_chf,
+            ist_aktion=True,
+            original_preis=preis_chf,
+            prozent=prozent,
+        )
+    return EffektivPreis(
+        preis=preis_chf,
+        ist_aktion=False,
+        original_preis=preis_chf,
+        prozent=0,
+    )

--- a/app/services/bestell_service.py
+++ b/app/services/bestell_service.py
@@ -1,6 +1,8 @@
 import sqlite3
+from datetime import date
 
 from app.models import WarenkorbItem
+from app.services.aktions_service import effektiver_preis
 
 
 def berechne_versandkosten(warenwert: float, versandart: str = "versand") -> float:
@@ -10,29 +12,52 @@ def berechne_versandkosten(warenwert: float, versandart: str = "versand") -> flo
 
 
 def berechne_total(
-    conn: sqlite3.Connection, items: list[WarenkorbItem]
+    conn: sqlite3.Connection,
+    items: list[WarenkorbItem],
+    heute: date | None = None,
 ) -> tuple[float, list[dict]]:
-    """Validiert Items gegen DB und berechnet Total.
+    """Validiert Items gegen DB und berechnet Total mit Effektiv-Preis.
 
-    Returns: (total, positionen) wobei positionen eine Liste von
-    {"produkt_id", "menge", "einzelpreis_chf"} ist.
+    Returns: (total, positionen) wobei jede Position
+    {"produkt_id", "menge", "einzelpreis_chf", "ist_aktion",
+     "original_preis_chf"} enthält.
     """
+    if heute is None:
+        heute = date.today()
     positionen = []
     total = 0.0
     for item in items:
         row = conn.execute(
-            "SELECT id, preis_chf FROM produkte WHERE id = ? AND aktiv = 1",
+            "SELECT id, preis_chf, aktionspreis_chf, aktion_von, aktion_bis "
+            "FROM produkte WHERE id = ? AND aktiv = 1",
             (item.produkt_id,),
         ).fetchone()
         if not row:
             raise ValueError(f"Produkt {item.produkt_id} nicht gefunden")
-        preis = row["preis_chf"]
+        ep = effektiver_preis(
+            row["preis_chf"],
+            row["aktionspreis_chf"],
+            row["aktion_von"],
+            row["aktion_bis"],
+            heute,
+        )
         positionen.append(
             {
                 "produkt_id": item.produkt_id,
                 "menge": item.menge,
-                "einzelpreis_chf": preis,
+                "einzelpreis_chf": ep.preis,
+                "ist_aktion": ep.ist_aktion,
+                "original_preis_chf": ep.original_preis,
             }
         )
-        total += preis * item.menge
+        total += ep.preis * item.menge
     return total, positionen
+
+
+def rabattfaehiger_subtotal(positionen: list[dict]) -> float:
+    """Summe der Nicht-Aktions-Positionen — Basis für Rabattcodes."""
+    return sum(
+        p["einzelpreis_chf"] * p["menge"]
+        for p in positionen
+        if not p["ist_aktion"]
+    )

--- a/app/services/bestell_service.py
+++ b/app/services/bestell_service.py
@@ -57,7 +57,5 @@ def berechne_total(
 def rabattfaehiger_subtotal(positionen: list[dict]) -> float:
     """Summe der Nicht-Aktions-Positionen — Basis für Rabattcodes."""
     return sum(
-        p["einzelpreis_chf"] * p["menge"]
-        for p in positionen
-        if not p["ist_aktion"]
+        p["einzelpreis_chf"] * p["menge"] for p in positionen if not p["ist_aktion"]
     )

--- a/docs/arc42.md
+++ b/docs/arc42.md
@@ -255,6 +255,8 @@ Eine Aktion ist aktiv wenn `aktionspreis_chf` gesetzt ist und das heutige Datum 
 
 **Admin Self-Service:** Der Shopbetreiber setzt und entfernt Aktionspreise unter `/admin/produkte` (CSRF-geschützt, Audit-Log-Eintrag bei jeder Änderung).
 
+**Persistenz über Neustarts (Bug #137):** `init_db()` führt den Produkt-Seed (`migrations/001_initial.sql`) bei jedem Container-Start erneut aus. Der Seed nutzt ein UPSERT (`ON CONFLICT(id) DO UPDATE`), das **nur die Katalog-Spalten** (`name`, `menge_ml`, `preis_chf`, `beschreibung`, `bild_pfad`) aktualisiert. Die admin-editierbaren Aktions-Spalten sind bewusst ausgenommen und überleben damit Deploys, fly.io-Maschinenneustarts und Litestream-Restores. Katalog-Korrekturen via Migration greifen weiterhin bei jedem Boot. Regel: Künftige admin-editierbare Spalten dürfen **nicht** in die UPSERT-Liste aufgenommen werden.
+
 ### Fehlerbehandlung
 - Fehlgeschlagene Zahlungen: Stripe gibt Fehlermeldung zurück → im Frontend anzeigen
 - Webhook-Fehler: Stripe wiederholt Webhooks automatisch bei Fehlern

--- a/docs/arc42.md
+++ b/docs/arc42.md
@@ -233,6 +233,28 @@ Vor dem Push wird lokal `make lint-all` (Ruff-Check + Format-Check) und `make te
 - BruteForceGuard auf `/admin/login` (Lockout nach 5 Fehlversuchen)
 - `.env`-Dateien nie ins Repository committen
 
+### Aktionspreise (Issue #134)
+
+Produktbezogene, befristete Aktionspreise werden über vier optionale Spalten in der Tabelle `produkte` verwaltet:
+
+| Spalte | Typ | Bedeutung |
+|---|---|---|
+| `aktionspreis_chf` | REAL, NULL | Aktionspreis; NULL = kein Aktionspreis aktiv |
+| `aktionstext` | TEXT, NULL | Begründungstext (z. B. "Frühlingsaktion") |
+| `aktion_von` | TEXT, NULL | Startdatum ISO 8601 (optional, leer = unbegrenzt) |
+| `aktion_bis` | TEXT, NULL | Enddatum ISO 8601 (optional, leer = unbegrenzt) |
+
+**Zentrale Preisfunktion:** `app/services/aktions_service.py:effektiver_preis(preis_chf, aktionspreis_chf, aktion_von, aktion_bis, heute)` ist die einzige Stelle, die entscheidet, welcher Preis gilt. Sie gibt ein `EffektivPreis`-Tupel zurück (`preis, ist_aktion, original_preis, prozent`). Alle nachgelagerten Stellen (Warenkorb-Total, Stripe Checkout, DB-Positionen, Bestätigungs-E-Mail, QR-Rechnung) rufen diese Funktion über `berechne_total()` auf — es gibt keine zweite Preis-Berechnung im System.
+
+Eine Aktion ist aktiv wenn `aktionspreis_chf` gesetzt ist und das heutige Datum innerhalb des optionalen Zeitfensters liegt. Nach Ablauf von `aktion_bis` greift automatisch wieder der Normalpreis — ohne manuellen Eingriff.
+
+**Abgrenzung zu Rabattcodes:**
+- Aktionspreise wirken auf den **Einzelpreis** (Produktebene) und sind auf der Produktkarte sichtbar (RABATT-Badge, durchgestrichener Originalpreis, Aktionspreis, –%-Badge, Begründungstext).
+- Rabattcodes wirken auf den **Warenkorb-Total** (Warenkorbebene).
+- Regel: Ein Rabattcode wird nur auf den `rabattfaehiger_subtotal` angewendet — das ist der Anteil des Warenkorbs ohne Aktionsartikel. Ein Warenkorb, der ausschliesslich Aktionsartikel enthält, lehnt einen Rabattcode ab.
+
+**Admin Self-Service:** Der Shopbetreiber setzt und entfernt Aktionspreise unter `/admin/produkte` (CSRF-geschützt, Audit-Log-Eintrag bei jeder Änderung).
+
 ### Fehlerbehandlung
 - Fehlgeschlagene Zahlungen: Stripe gibt Fehlermeldung zurück → im Frontend anzeigen
 - Webhook-Fehler: Stripe wiederholt Webhooks automatisch bei Fehlern

--- a/docs/superpowers/plans/2026-06-23-aktionspreise.md
+++ b/docs/superpowers/plans/2026-06-23-aktionspreise.md
@@ -1,0 +1,1448 @@
+# Produktbezogene Aktionspreise — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Einzelne Produkte können einen temporären, auf der Produktkarte sichtbaren Aktionspreis (mit Begründungstext und optionalem Gültigkeitszeitraum) erhalten, den der SH selbst über die Admin-UI pflegt.
+
+**Architecture:** Eine zentrale Funktion `effektiver_preis()` ist die einzige Stelle, die entscheidet, welcher Preis (Normal- oder Aktionspreis) zu einem Datum gilt. Sie speist die autoritative Serverberechnung `berechne_total()`, wodurch Stripe, DB-Positionen, Mails und QR-Rechnung automatisch korrekt rechnen. Rabattcodes greifen nur auf den Nicht-Aktions-Anteil des Warenkorbs.
+
+**Tech Stack:** Python 3 / FastAPI, SQLite, Jinja2, Tailwind CSS, Vanilla JS (localStorage-Warenkorb), pytest, Stripe.
+
+## Global Constraints
+
+- **UI-Texte Deutsch (CH).** Keine englischen Strings im sichtbaren UI.
+- **Preis-Autorität ist der Server.** `berechne_total()` ist die einzige verbindliche Preisquelle; der Browser-Warenkorb dient nur der Anzeige.
+- **Neue Spalten an bestehenden Tabellen** werden idempotent via `_add_column_if_not_exists()` in `init_db()` ergänzt — **kein** `ALTER TABLE` in einer `.sql`-Datei (würde beim Re-Run scheitern). Dasselbe in der `db`-Fixture in `tests/conftest.py` spiegeln.
+- **Ruff-konformer Stil** (Linter + Formatter). Vor jedem Commit lokal `make lint-all` bzw. `ruff check .` grün.
+- **Geldbeträge** in CHF, 2 Nachkommastellen; bestehende 5-Rappen-Rundung der Rabattcodes nicht verändern.
+- **CSRF**: Admin-POST-Routen mit Zustandsänderung schützen via `Depends(require_csrf)` (Muster aus `app/routers/admin.py`).
+- **Commit-Konvention**: `feat:`, `fix:`, `docs:`, `refactor:`, `test:`.
+
+---
+
+### Task 1: DB-Spalten für Aktionspreise
+
+Vier NULL-bare Spalten an `produkte` ergänzen — idempotent in `init_db()` und in der Test-Fixture.
+
+**Files:**
+- Modify: `app/database.py` (Funktion `init_db`)
+- Modify: `tests/conftest.py` (Fixture `db`)
+- Test: `tests/test_aktions_columns.py` (neu)
+
+**Interfaces:**
+- Produces: Tabelle `produkte` hat die Spalten `aktionspreis_chf` (REAL NULL), `aktionstext` (TEXT NULL), `aktion_von` (TEXT NULL), `aktion_bis` (TEXT NULL).
+
+- [ ] **Step 1: Failing test schreiben**
+
+`tests/test_aktions_columns.py`:
+
+```python
+def test_produkte_hat_aktions_spalten(db):
+    cols = {row[1] for row in db.execute("PRAGMA table_info(produkte)")}
+    assert {"aktionspreis_chf", "aktionstext", "aktion_von", "aktion_bis"} <= cols
+```
+
+- [ ] **Step 2: Test laufen lassen — muss fehlschlagen**
+
+Run: `uv run pytest tests/test_aktions_columns.py -v`
+Expected: FAIL (Spalten fehlen).
+
+- [ ] **Step 3: Spalten in `init_db()` ergänzen**
+
+In `app/database.py`, in `init_db()` nach den bestehenden `_add_column_if_not_exists`-Aufrufen (vor `conn.commit()`):
+
+```python
+        _add_column_if_not_exists(conn, "produkte", "aktionspreis_chf", "REAL")
+        _add_column_if_not_exists(conn, "produkte", "aktionstext", "TEXT")
+        _add_column_if_not_exists(conn, "produkte", "aktion_von", "TEXT")
+        _add_column_if_not_exists(conn, "produkte", "aktion_bis", "TEXT")
+```
+
+- [ ] **Step 4: Dieselben Spalten in der `db`-Fixture ergänzen**
+
+In `tests/conftest.py`, in der `db`-Fixture nach den bestehenden `_add_column_if_not_exists`-Aufrufen (vor `conn.commit()`):
+
+```python
+    _add_column_if_not_exists(conn, "produkte", "aktionspreis_chf", "REAL")
+    _add_column_if_not_exists(conn, "produkte", "aktionstext", "TEXT")
+    _add_column_if_not_exists(conn, "produkte", "aktion_von", "TEXT")
+    _add_column_if_not_exists(conn, "produkte", "aktion_bis", "TEXT")
+```
+
+- [ ] **Step 5: Test laufen lassen — muss bestehen**
+
+Run: `uv run pytest tests/test_aktions_columns.py -v`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/database.py tests/conftest.py tests/test_aktions_columns.py
+git commit -m "feat: Aktionspreis-Spalten an produkte (#134)"
+```
+
+---
+
+### Task 2: Effektiv-Preis-Logik (`aktions_service`)
+
+Die zentrale, rein funktionale Preisentscheidung. Keine DB, keine Seiteneffekte — vollständig unit-testbar.
+
+**Files:**
+- Create: `app/services/aktions_service.py`
+- Test: `tests/test_aktions_service.py` (neu)
+
+**Interfaces:**
+- Produces:
+  - `class EffektivPreis(NamedTuple)` mit Feldern `preis: float`, `ist_aktion: bool`, `original_preis: float`, `prozent: int`.
+  - `effektiver_preis(preis_chf: float, aktionspreis_chf: float | None, aktion_von: str | None, aktion_bis: str | None, heute: date) -> EffektivPreis`. `aktion_von`/`aktion_bis` sind ISO-Strings (`YYYY-MM-DD`) oder `None`/`""`. Bei aktiver Aktion ist `preis` der Aktionspreis, sonst der Normalpreis. `prozent = round((1 - aktion/original) * 100)`, sonst `0`.
+
+- [ ] **Step 1: Failing tests schreiben**
+
+`tests/test_aktions_service.py`:
+
+```python
+from datetime import date
+
+from app.services.aktions_service import effektiver_preis
+
+HEUTE = date(2026, 6, 23)
+
+
+def test_keine_aktion_wenn_aktionspreis_none():
+    ep = effektiver_preis(18.0, None, None, None, HEUTE)
+    assert ep.ist_aktion is False
+    assert ep.preis == 18.0
+    assert ep.original_preis == 18.0
+    assert ep.prozent == 0
+
+
+def test_aktion_ohne_datumsgrenzen_gilt():
+    ep = effektiver_preis(18.0, 12.0, None, None, HEUTE)
+    assert ep.ist_aktion is True
+    assert ep.preis == 12.0
+    assert ep.original_preis == 18.0
+    assert ep.prozent == 33  # round((1-12/18)*100) = 33
+
+
+def test_aktion_vor_beginn_inaktiv():
+    ep = effektiver_preis(18.0, 12.0, "2026-07-01", None, HEUTE)
+    assert ep.ist_aktion is False
+    assert ep.preis == 18.0
+
+
+def test_aktion_nach_ende_inaktiv():
+    ep = effektiver_preis(18.0, 12.0, None, "2026-06-22", HEUTE)
+    assert ep.ist_aktion is False
+    assert ep.preis == 18.0
+
+
+def test_aktion_innerhalb_zeitraum_aktiv():
+    ep = effektiver_preis(18.0, 12.0, "2026-06-01", "2026-06-30", HEUTE)
+    assert ep.ist_aktion is True
+    assert ep.preis == 12.0
+
+
+def test_aktion_grenze_von_inklusive():
+    ep = effektiver_preis(18.0, 12.0, "2026-06-23", "2026-06-30", HEUTE)
+    assert ep.ist_aktion is True
+
+
+def test_aktion_grenze_bis_inklusive():
+    ep = effektiver_preis(18.0, 12.0, "2026-06-01", "2026-06-23", HEUTE)
+    assert ep.ist_aktion is True
+
+
+def test_leere_strings_wie_none_behandelt():
+    ep = effektiver_preis(18.0, 12.0, "", "", HEUTE)
+    assert ep.ist_aktion is True
+```
+
+- [ ] **Step 2: Tests laufen lassen — müssen fehlschlagen**
+
+Run: `uv run pytest tests/test_aktions_service.py -v`
+Expected: FAIL (Modul/Funktion fehlt).
+
+- [ ] **Step 3: Implementierung schreiben**
+
+`app/services/aktions_service.py`:
+
+```python
+"""Zentrale Logik für produktbezogene Aktionspreise (Issue #134).
+
+Einzige Stelle, die entscheidet, ob und welcher Aktionspreis zu einem
+gegebenen Datum gilt. Rein funktional, ohne DB-Zugriff.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import NamedTuple
+
+
+class EffektivPreis(NamedTuple):
+    preis: float
+    ist_aktion: bool
+    original_preis: float
+    prozent: int
+
+
+def _aktion_aktiv(
+    aktionspreis_chf: float | None,
+    aktion_von: str | None,
+    aktion_bis: str | None,
+    heute: date,
+) -> bool:
+    if aktionspreis_chf is None:
+        return False
+    h = heute.isoformat()
+    if aktion_von and h < aktion_von:
+        return False
+    if aktion_bis and h > aktion_bis:
+        return False
+    return True
+
+
+def effektiver_preis(
+    preis_chf: float,
+    aktionspreis_chf: float | None,
+    aktion_von: str | None,
+    aktion_bis: str | None,
+    heute: date,
+) -> EffektivPreis:
+    """Liefert den gültigen Preis samt Aktions-Metadaten für ein Datum."""
+    if _aktion_aktiv(aktionspreis_chf, aktion_von, aktion_bis, heute):
+        prozent = round((1 - aktionspreis_chf / preis_chf) * 100)
+        return EffektivPreis(
+            preis=aktionspreis_chf,
+            ist_aktion=True,
+            original_preis=preis_chf,
+            prozent=prozent,
+        )
+    return EffektivPreis(
+        preis=preis_chf,
+        ist_aktion=False,
+        original_preis=preis_chf,
+        prozent=0,
+    )
+```
+
+- [ ] **Step 4: Tests laufen lassen — müssen bestehen**
+
+Run: `uv run pytest tests/test_aktions_service.py -v`
+Expected: PASS (8 Tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/aktions_service.py tests/test_aktions_service.py
+git commit -m "feat: effektiver_preis-Logik für Aktionspreise (#134)"
+```
+
+---
+
+### Task 3: Produkt-Model & Repo um Aktions-Felder erweitern
+
+`Produkt` trägt die Aktions-Felder, `get_alle_produkte()` lädt sie mit.
+
+**Files:**
+- Modify: `app/models.py` (`class Produkt`)
+- Modify: `app/repositories/produkt_repo.py` (`get_alle_produkte`)
+- Test: `tests/test_produkt_repo.py` (ergänzen)
+
+**Interfaces:**
+- Consumes: DB-Spalten aus Task 1.
+- Produces: `Produkt` hat zusätzlich `aktionspreis_chf: float | None = None`, `aktionstext: str | None = None`, `aktion_von: str | None = None`, `aktion_bis: str | None = None`. `get_alle_produkte()` füllt diese Felder.
+
+- [ ] **Step 1: Failing test ergänzen**
+
+In `tests/test_produkt_repo.py` ergänzen (eine aktive Aktion auf Produkt 2 setzen, dann laden):
+
+```python
+def test_get_alle_produkte_liefert_aktions_felder(db):
+    from app.repositories.produkt_repo import get_alle_produkte
+
+    db.execute(
+        "UPDATE produkte SET aktionspreis_chf = 12.0, aktionstext = 'MHD 09/2026', "
+        "aktion_von = '2026-06-01', aktion_bis = '2026-06-30' WHERE id = 2"
+    )
+    db.commit()
+    produkte = get_alle_produkte(db)
+    p2 = next(p for p in produkte if p.id == 2)
+    assert p2.aktionspreis_chf == 12.0
+    assert p2.aktionstext == "MHD 09/2026"
+    assert p2.aktion_von == "2026-06-01"
+    assert p2.aktion_bis == "2026-06-30"
+
+
+def test_get_alle_produkte_ohne_aktion_felder_none(db):
+    from app.repositories.produkt_repo import get_alle_produkte
+
+    produkte = get_alle_produkte(db)
+    p1 = next(p for p in produkte if p.id == 1)
+    assert p1.aktionspreis_chf is None
+```
+
+- [ ] **Step 2: Tests laufen lassen — müssen fehlschlagen**
+
+Run: `uv run pytest tests/test_produkt_repo.py -v`
+Expected: FAIL (Felder fehlen / SELECT liefert sie nicht).
+
+- [ ] **Step 3: Model erweitern**
+
+In `app/models.py`, `class Produkt` um vier Felder nach `aktiv: bool = True` ergänzen:
+
+```python
+    aktionspreis_chf: float | None = None
+    aktionstext: str | None = None
+    aktion_von: str | None = None
+    aktion_bis: str | None = None
+```
+
+- [ ] **Step 4: SELECT in `get_alle_produkte` erweitern**
+
+In `app/repositories/produkt_repo.py` das SELECT ersetzen:
+
+```python
+def get_alle_produkte(conn: sqlite3.Connection) -> list[Produkt]:
+    rows = conn.execute(
+        "SELECT id, name, menge_ml, preis_chf, beschreibung, bild_pfad, aktiv, "
+        "aktionspreis_chf, aktionstext, aktion_von, aktion_bis "
+        "FROM produkte WHERE aktiv = 1 ORDER BY menge_ml"
+    ).fetchall()
+    return [Produkt(**dict(row)) for row in rows]
+```
+
+- [ ] **Step 5: Tests laufen lassen — müssen bestehen**
+
+Run: `uv run pytest tests/test_produkt_repo.py tests/test_models.py -v`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/models.py app/repositories/produkt_repo.py tests/test_produkt_repo.py
+git commit -m "feat: Produkt-Model und Repo um Aktions-Felder (#134)"
+```
+
+---
+
+### Task 4: `berechne_total` rechnet mit Effektiv-Preis + rabattfähiger Subtotal
+
+Die autoritative Serverberechnung nutzt den Aktionspreis und markiert Aktionspositionen.
+
+**Files:**
+- Modify: `app/services/bestell_service.py`
+- Test: `tests/test_bestell_service.py` (ergänzen)
+
+**Interfaces:**
+- Consumes: `effektiver_preis(...)` (Task 2), Aktions-Spalten (Task 1).
+- Produces:
+  - `berechne_total(conn, items, heute: date | None = None) -> tuple[float, list[dict]]`. Jede Position-Dict hat jetzt zusätzlich `ist_aktion: bool` und `original_preis_chf: float`; `einzelpreis_chf` ist der Effektiv-Preis. `heute` default `date.today()`.
+  - `rabattfaehiger_subtotal(positionen: list[dict]) -> float` — Summe `einzelpreis_chf * menge` über alle Positionen mit `ist_aktion is False`.
+
+- [ ] **Step 1: Failing tests ergänzen**
+
+In `tests/test_bestell_service.py` ergänzen:
+
+```python
+from datetime import date
+
+from app.services.bestell_service import rabattfaehiger_subtotal
+
+
+def test_berechne_total_mit_aktionspreis(db):
+    db.execute(
+        "UPDATE produkte SET aktionspreis_chf = 12.0, aktion_von = '2026-06-01', "
+        "aktion_bis = '2026-06-30' WHERE id = 2"
+    )
+    db.commit()
+    items = [WarenkorbItem(produkt_id=2, menge=1)]  # statt 18 jetzt 12
+    total, positionen = berechne_total(db, items, heute=date(2026, 6, 23))
+    assert total == 12.0
+    assert positionen[0]["einzelpreis_chf"] == 12.0
+    assert positionen[0]["ist_aktion"] is True
+    assert positionen[0]["original_preis_chf"] == 18.0
+
+
+def test_berechne_total_aktion_abgelaufen_normalpreis(db):
+    db.execute(
+        "UPDATE produkte SET aktionspreis_chf = 12.0, aktion_bis = '2026-06-22' "
+        "WHERE id = 2"
+    )
+    db.commit()
+    items = [WarenkorbItem(produkt_id=2, menge=1)]
+    total, positionen = berechne_total(db, items, heute=date(2026, 6, 23))
+    assert total == 18.0
+    assert positionen[0]["ist_aktion"] is False
+
+
+def test_rabattfaehiger_subtotal_nur_nicht_aktion():
+    positionen = [
+        {"einzelpreis_chf": 8.0, "menge": 2, "ist_aktion": False},  # 16
+        {"einzelpreis_chf": 12.0, "menge": 1, "ist_aktion": True},  # ausgeschlossen
+    ]
+    assert rabattfaehiger_subtotal(positionen) == 16.0
+
+
+def test_rabattfaehiger_subtotal_reine_aktion_null():
+    positionen = [{"einzelpreis_chf": 12.0, "menge": 1, "ist_aktion": True}]
+    assert rabattfaehiger_subtotal(positionen) == 0.0
+```
+
+- [ ] **Step 2: Tests laufen lassen — müssen fehlschlagen**
+
+Run: `uv run pytest tests/test_bestell_service.py -v`
+Expected: FAIL.
+
+- [ ] **Step 3: `berechne_total` + Helper implementieren**
+
+`app/services/bestell_service.py` — Imports oben ergänzen und Funktionen ersetzen/ergänzen:
+
+```python
+import sqlite3
+from datetime import date
+
+from app.models import WarenkorbItem
+from app.services.aktions_service import effektiver_preis
+
+
+def berechne_versandkosten(warenwert: float, versandart: str = "versand") -> float:
+    if versandart == "abholung":
+        return 0.0
+    return 0.0 if warenwert >= 100 else 9.90
+
+
+def berechne_total(
+    conn: sqlite3.Connection,
+    items: list[WarenkorbItem],
+    heute: date | None = None,
+) -> tuple[float, list[dict]]:
+    """Validiert Items gegen DB und berechnet Total mit Effektiv-Preis.
+
+    Returns: (total, positionen) wobei jede Position
+    {"produkt_id", "menge", "einzelpreis_chf", "ist_aktion",
+     "original_preis_chf"} enthält.
+    """
+    if heute is None:
+        heute = date.today()
+    positionen = []
+    total = 0.0
+    for item in items:
+        row = conn.execute(
+            "SELECT id, preis_chf, aktionspreis_chf, aktion_von, aktion_bis "
+            "FROM produkte WHERE id = ? AND aktiv = 1",
+            (item.produkt_id,),
+        ).fetchone()
+        if not row:
+            raise ValueError(f"Produkt {item.produkt_id} nicht gefunden")
+        ep = effektiver_preis(
+            row["preis_chf"],
+            row["aktionspreis_chf"],
+            row["aktion_von"],
+            row["aktion_bis"],
+            heute,
+        )
+        positionen.append(
+            {
+                "produkt_id": item.produkt_id,
+                "menge": item.menge,
+                "einzelpreis_chf": ep.preis,
+                "ist_aktion": ep.ist_aktion,
+                "original_preis_chf": ep.original_preis,
+            }
+        )
+        total += ep.preis * item.menge
+    return total, positionen
+
+
+def rabattfaehiger_subtotal(positionen: list[dict]) -> float:
+    """Summe der Nicht-Aktions-Positionen — Basis für Rabattcodes."""
+    return sum(
+        p["einzelpreis_chf"] * p["menge"]
+        for p in positionen
+        if not p["ist_aktion"]
+    )
+```
+
+- [ ] **Step 4: Tests laufen lassen — müssen bestehen**
+
+Run: `uv run pytest tests/test_bestell_service.py -v`
+Expected: PASS (inkl. der bestehenden `test_berechne_total`-Tests, da Verhalten ohne Aktion unverändert).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/bestell_service.py tests/test_bestell_service.py
+git commit -m "feat: berechne_total nutzt Aktionspreis + rabattfähiger Subtotal (#134)"
+```
+
+---
+
+### Task 5: Bestell-Route — Rabattcode nur auf Nicht-Aktions-Anteil
+
+Die Order-Route nutzt den rabattfähigen Subtotal und lehnt Codes bei reinem Aktions-Warenkorb ab.
+
+**Files:**
+- Modify: `app/routers/bestellungen.py` (Block ab `total, positionen = berechne_total(...)`)
+- Test: `tests/test_aktionspreis_bestellung.py` (neu)
+
+**Interfaces:**
+- Consumes: `rabattfaehiger_subtotal()` (Task 4), `pruefe_rabattcode()`.
+- Produces: Bei gemischtem Warenkorb bezieht sich der Rabatt nur auf Nicht-Aktionsware; reiner Aktions-Warenkorb mit Code → HTTP 400.
+
+- [ ] **Step 1: Failing tests schreiben**
+
+`tests/test_aktionspreis_bestellung.py`:
+
+```python
+import json
+
+
+def _setze_aktion(produkt_id, aktionspreis):
+    from app.database import get_db
+
+    conn = get_db()
+    conn.execute(
+        "UPDATE produkte SET aktionspreis_chf = ? WHERE id = ?",
+        (aktionspreis, produkt_id),
+    )
+    conn.commit()
+    conn.close()
+
+
+def _erstelle_rabattcode(code, art, wert):
+    from app.database import get_db
+
+    conn = get_db()
+    conn.execute(
+        "INSERT INTO rabattcodes (code, rabattart, rabattwert, gueltig_von, "
+        "gueltig_bis) VALUES (?, ?, ?, '2026-01-01', '2026-12-31')",
+        (code, art, wert),
+    )
+    conn.commit()
+    conn.close()
+
+
+def test_code_nur_auf_nicht_aktions_anteil(client, csrf_token):
+    from app.database import get_db
+
+    _setze_aktion(2, 12.0)  # Produkt 2 in Aktion
+    _erstelle_rabattcode("ZEHN", "prozent", 10.0)
+    # Warenkorb: 1x Produkt 1 (8.- normal) + 1x Produkt 2 (12.- Aktion)
+    cart = json.dumps([{"produkt_id": 1, "menge": 1}, {"produkt_id": 2, "menge": 1}])
+    resp = client.post(
+        "/bestellen",
+        data={
+            "vorname": "T", "nachname": "U", "email": "t@example.com",
+            "strasse": "Str. 1", "plz": "4600", "ort": "Olten",
+            "versandart": "abholung", "zahlungsart": "abholung_bar",
+            "cart_data": cart, "rabattcode": "ZEHN", "csrf_token": csrf_token,
+        },
+        follow_redirects=False,
+    )
+    assert resp.status_code in (200, 303)
+    conn = get_db()
+    row = conn.execute(
+        "SELECT rabattbetrag_chf, total_chf FROM bestellungen WHERE id = 1"
+    ).fetchone()
+    conn.close()
+    # 10% nur auf den 8.- Nicht-Aktionsanteil = 0.80 (5-Rappen-gerundet)
+    assert row["rabattbetrag_chf"] == 0.80
+    # Total: 8 + 12 - 0.80 + 0 Versand = 19.20
+    assert row["total_chf"] == 19.20
+
+
+def test_reiner_aktionswarenkorb_lehnt_code_ab(client, csrf_token):
+    _setze_aktion(2, 12.0)
+    _erstelle_rabattcode("ZEHN", "prozent", 10.0)
+    cart = json.dumps([{"produkt_id": 2, "menge": 1}])  # nur Aktionsware
+    resp = client.post(
+        "/bestellen",
+        data={
+            "vorname": "T", "nachname": "U", "email": "t@example.com",
+            "strasse": "Str. 1", "plz": "4600", "ort": "Olten",
+            "versandart": "abholung", "zahlungsart": "abholung_bar",
+            "cart_data": cart, "rabattcode": "ZEHN", "csrf_token": csrf_token,
+        },
+        follow_redirects=False,
+    )
+    assert resp.status_code == 400
+```
+
+> Hinweis: Ohne explizite `aktion_von/aktion_bis` gilt die Aktion sofort und unbegrenzt — `date.today()` liegt im Gültigkeitsbereich.
+
+- [ ] **Step 2: Tests laufen lassen — müssen fehlschlagen**
+
+Run: `uv run pytest tests/test_aktionspreis_bestellung.py -v`
+Expected: FAIL (Rabatt aktuell auf vollem Total).
+
+- [ ] **Step 3: Rabattcode-Block in `bestellungen.py` anpassen**
+
+In `app/routers/bestellungen.py`: Import-Zeile erweitern:
+
+```python
+from app.services.bestell_service import (
+    berechne_total,
+    berechne_versandkosten,
+    rabattfaehiger_subtotal,
+)
+```
+
+Den Rabattcode-Block (aktuell ab `if rabattcode:` mit `pruefe_rabattcode(conn, rabattcode, email, total)`) ersetzen durch:
+
+```python
+        # Rabattcode pruefen — gilt nur auf Nicht-Aktions-Anteil
+        rabattcode_id = None
+        rabattbetrag = 0.0
+        if rabattcode:
+            from app.services.rabattcode_service import pruefe_rabattcode
+
+            rabattbasis = rabattfaehiger_subtotal(positionen)
+            if rabattbasis <= 0:
+                raise ValueError(
+                    "Auf Aktionsprodukte ist kein zusätzlicher Rabattcode möglich."
+                )
+            rc_result = pruefe_rabattcode(conn, rabattcode, email, rabattbasis)
+            if rc_result["gueltig"]:
+                rabattcode_id = rc_result["rabattcode_id"]
+                rabattbetrag = rc_result["rabattbetrag"]
+            else:
+                raise ValueError(f"Rabattcode ungültig: {rc_result['fehler']}")
+```
+
+> Die bestehende `versandkosten = berechne_versandkosten(total, versandart)`-Zeile und `gesamt = total - rabattbetrag + versandkosten` bleiben unverändert (Versand auf vollem Warenwert, Total korrekt).
+
+- [ ] **Step 4: Tests laufen lassen — müssen bestehen**
+
+Run: `uv run pytest tests/test_aktionspreis_bestellung.py tests/test_api_rabattcodes.py -v`
+Expected: PASS (auch bestehende Rabattcode-Tests grün, da ohne Aktion `rabattbasis == total`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/routers/bestellungen.py tests/test_aktionspreis_bestellung.py
+git commit -m "feat: Rabattcode greift nur auf Nicht-Aktions-Anteil (#134)"
+```
+
+---
+
+### Task 6: Produktkarte zeigt Aktionspreis
+
+Die Startseite rendert Badge, durchgestrichenen Originalpreis, Aktionspreis, Prozent-Badge und Begründungstext; `data-product-price` trägt den Aktionspreis.
+
+**Files:**
+- Modify: `app/routers/produkte.py` (`startseite`)
+- Modify: `templates/produkte.html`
+- Test: `tests/test_api_produkte.py` (ergänzen)
+
+**Interfaces:**
+- Consumes: `effektiver_preis()` (Task 2), `get_alle_produkte()` (Task 3).
+- Produces: Template-Context `produkte` ist eine Liste von Dicts mit `id, name, beschreibung, bild_pfad, preis, ist_aktion, original_preis, prozent, aktionstext`.
+
+- [ ] **Step 1: Failing test ergänzen**
+
+In `tests/test_api_produkte.py` ergänzen:
+
+```python
+def test_startseite_zeigt_aktionspreis(client):
+    from app.database import get_db
+
+    conn = get_db()
+    conn.execute(
+        "UPDATE produkte SET aktionspreis_chf = 12.0, "
+        "aktionstext = 'MHD 09/2026' WHERE id = 2"
+    )
+    conn.commit()
+    conn.close()
+    resp = client.get("/")
+    assert resp.status_code == 200
+    assert "RABATT" in resp.text
+    assert "MHD 09/2026" in resp.text
+    assert "CHF 12.00" in resp.text
+
+
+def test_startseite_ohne_aktion_kein_badge(client):
+    resp = client.get("/")
+    assert resp.status_code == 200
+    assert "RABATT" not in resp.text
+```
+
+- [ ] **Step 2: Tests laufen lassen — müssen fehlschlagen**
+
+Run: `uv run pytest tests/test_api_produkte.py -v`
+Expected: FAIL.
+
+- [ ] **Step 3: Produkte-Route Context aufbauen**
+
+`app/routers/produkte.py` ersetzen:
+
+```python
+from datetime import date
+
+from fastapi import APIRouter, Request
+
+from app.database import get_db
+from app.repositories.produkt_repo import get_alle_produkte
+from app.services.aktions_service import effektiver_preis
+from app.templating import templates
+
+router = APIRouter()
+
+
+@router.get("/")
+def startseite(request: Request):
+    conn = get_db()
+    try:
+        produkte = get_alle_produkte(conn)
+    finally:
+        conn.close()
+    heute = date.today()
+    ansichten = []
+    for p in produkte:
+        ep = effektiver_preis(
+            p.preis_chf, p.aktionspreis_chf, p.aktion_von, p.aktion_bis, heute
+        )
+        ansichten.append(
+            {
+                "id": p.id,
+                "name": p.name,
+                "beschreibung": p.beschreibung,
+                "bild_pfad": p.bild_pfad,
+                "preis": ep.preis,
+                "ist_aktion": ep.ist_aktion,
+                "original_preis": ep.original_preis,
+                "prozent": ep.prozent,
+                "aktionstext": p.aktionstext,
+            }
+        )
+    return templates.TemplateResponse(
+        request, "produkte.html", {"produkte": ansichten, "active_page": "produkte"}
+    )
+```
+
+- [ ] **Step 4: Produktkarte im Template anpassen**
+
+In `templates/produkte.html` den Karten-Block (`{% for produkt in produkte %}` … `{% endfor %}`) ersetzen. Karte als `relative` für das Badge; Preisbereich zeigt bei Aktion durchgestrichenen Originalpreis + Aktionspreis + Prozent-Badge + Begründungstext:
+
+```html
+                {% for produkt in produkte %}
+                <div class="relative bg-stone-900/75 backdrop-blur-[4px] rounded-lg p-6 flex flex-col shadow-md border border-stone-600/15 hover:shadow-lg hover:-translate-y-1 transition-all duration-200">
+                    {% if produkt.ist_aktion %}
+                    <span class="absolute top-3 right-3 bg-red-600 text-white text-xs font-bold px-2 py-1 rounded">RABATT</span>
+                    {% endif %}
+                    {% if produkt.bild_pfad %}
+                    <img src="/static/images/{{ produkt.bild_pfad }}" alt="{{ produkt.name }}"
+                         class="w-full h-48 object-contain mb-4">
+                    {% endif %}
+                    <h3 class="font-display text-2xl font-bold text-accent">{{ produkt.name }}</h3>
+                    <p class="text-stone-200 mt-2 flex-1">{{ produkt.beschreibung }}</p>
+                    {% if produkt.ist_aktion and produkt.aktionstext %}
+                    <p class="text-accent text-sm mt-2">{{ produkt.aktionstext }}</p>
+                    {% endif %}
+                    <div class="mt-4 flex items-center justify-between">
+                        <div class="flex items-baseline gap-2">
+                            {% if produkt.ist_aktion %}
+                            <span class="text-stone-400 line-through text-sm">CHF {{ "%.2f"|format(produkt.original_preis) }}</span>
+                            <span class="text-xl font-bold">CHF {{ "%.2f"|format(produkt.preis) }}</span>
+                            <span class="bg-accent text-stone-900 text-xs font-bold px-1.5 py-0.5 rounded">−{{ produkt.prozent }}%</span>
+                            {% else %}
+                            <span class="text-xl font-bold">CHF {{ "%.2f"|format(produkt.preis) }}</span>
+                            {% endif %}
+                        </div>
+                        <button type="button"
+                                class="add-to-cart-btn bg-accent text-stone-900 px-4 py-2 rounded font-bold hover:bg-yellow-400 transition-colors"
+                                data-product-id="{{ produkt.id }}"
+                                data-product-name="{{ produkt.name }}"
+                                data-product-price="{{ produkt.preis }}"
+                                data-product-aktion="{{ '1' if produkt.ist_aktion else '0' }}"
+                                data-product-image="/static/images/{{ produkt.bild_pfad }}">
+                            In den Warenkorb
+                        </button>
+                    </div>
+                </div>
+                {% endfor %}
+```
+
+- [ ] **Step 5: Tests laufen lassen — müssen bestehen**
+
+Run: `uv run pytest tests/test_api_produkte.py -v`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/routers/produkte.py templates/produkte.html tests/test_api_produkte.py
+git commit -m "feat: Produktkarte zeigt Aktionspreis, Badge und Ersparnis (#134)"
+```
+
+---
+
+### Task 7: Warenkorb & Checkout-Vorschau berücksichtigen Aktionsware
+
+Warenkorb-Items tragen ein `aktion`-Flag; die Rabattcode-Live-Vorschau im Checkout bezieht sich auf den Nicht-Aktions-Subtotal.
+
+**Files:**
+- Modify: `static/js/cart.js` (`addToCart`, neue `getRabattSubtotal`, Klick-Handler)
+- Modify: `templates/checkout.html` (Vorschau-Script: `getRabattSubtotal()` statt `getCartTotal()` als `subtotal`)
+- Verifikation: manuell (kein JS-Test-Harness im Projekt)
+
+**Interfaces:**
+- Consumes: `data-product-aktion`-Attribut aus Task 6.
+- Produces: Warenkorb-Items haben Feld `aktion: bool`. `getRabattSubtotal()` summiert nur Nicht-Aktions-Items. Server bleibt autoritativ (Task 5).
+
+- [ ] **Step 1: `addToCart` und Klick-Handler um Aktions-Flag erweitern**
+
+In `static/js/cart.js`:
+
+`addToCart`-Signatur und Push erweitern:
+
+```javascript
+function addToCart(id, name, price, image, buttonEl, aktion) {
+    const cart = getCart();
+    const existing = cart.find((item) => item.produkt_id === id);
+    if (existing) {
+        existing.menge += 1;
+    } else {
+        cart.push({ produkt_id: id, name: name, preis: price, image: image, menge: 1, aktion: !!aktion });
+    }
+    saveCart(cart);
+```
+
+(Rest der Funktion unverändert.)
+
+Den delegierten Klick-Handler am Dateiende erweitern:
+
+```javascript
+document.addEventListener("click", (e) => {
+    const btn = e.target.closest(".add-to-cart-btn[data-product-id]");
+    if (!btn) return;
+    addToCart(
+        parseInt(btn.dataset.productId, 10),
+        btn.dataset.productName,
+        parseFloat(btn.dataset.productPrice),
+        btn.dataset.productImage,
+        btn,
+        btn.dataset.productAktion === "1"
+    );
+});
+```
+
+Und eine Helper-Funktion nach `getCartTotal()` ergänzen:
+
+```javascript
+function getRabattSubtotal() {
+    return getCart().reduce((sum, item) => sum + (item.aktion ? 0 : item.preis * item.menge), 0);
+}
+```
+
+- [ ] **Step 2: Checkout-Vorschau auf rabattfähigen Subtotal umstellen**
+
+In `templates/checkout.html`, Funktion `rabattcodeEinloesen()`: die Zeile
+
+```javascript
+    var subtotal = getCartTotal();
+```
+
+ersetzen durch:
+
+```javascript
+    var subtotal = getRabattSubtotal();
+    if (subtotal <= 0) {
+        zeigeFeedback("Auf Aktionsprodukte ist kein zusätzlicher Rabattcode möglich.", false);
+        return;
+    }
+```
+
+> Die Preis-Zusammenfassung (`aktualisierePreiszusammenfassung`) nutzt weiterhin `getCartTotal()` für Warenkorb/Versand/Total — korrekt, da der Warenkorb bereits Aktionspreise enthält. Nur die an die Vorschau-API gesendete Rabattbasis ändert sich. Der Server (Task 5) bleibt die finale Autorität.
+
+- [ ] **Step 3: Bestehende Tests laufen lassen (Regression)**
+
+Run: `uv run pytest tests/test_api_rabattcodes.py -v`
+Expected: PASS (Server-API unverändert; JS nicht von pytest abgedeckt).
+
+- [ ] **Step 4: Manuelle Verifikation (dokumentieren, nicht blockierend)**
+
+Lokal `make run` (oder Projektäquivalent), dann im Browser:
+1. Produkt mit Aktion + Normalprodukt in den Warenkorb legen.
+2. Checkout: Rabattcode einlösen → Rabatt nur auf Normalprodukt-Anteil.
+3. Nur Aktionsprodukt im Korb → Code-Einlösung zeigt Hinweis, kein Rabatt.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add static/js/cart.js templates/checkout.html
+git commit -m "feat: Warenkorb-Aktionsflag und Rabattcode-Vorschau ohne Aktionsware (#134)"
+```
+
+---
+
+### Task 8: Admin-Repo — Produkte laden & Aktion setzen/entfernen
+
+Repo-Funktionen für die Admin-UI: alle Produkte (inkl. inaktive), einzelnes Produkt, Aktion setzen, Aktion entfernen.
+
+**Files:**
+- Modify: `app/repositories/produkt_repo.py`
+- Test: `tests/test_produkt_repo.py` (ergänzen)
+
+**Interfaces:**
+- Produces:
+  - `alle_produkte_admin(conn) -> list[dict]` — alle Produkte mit Aktions-Spalten, sortiert nach `menge_ml`.
+  - `produkt_laden(conn, produkt_id: int) -> dict | None`.
+  - `aktion_setzen(conn, produkt_id, *, aktionspreis_chf: float, aktionstext: str, aktion_von: str | None, aktion_bis: str | None) -> None`.
+  - `aktion_entfernen(conn, produkt_id: int) -> None` — setzt alle vier Aktions-Spalten auf NULL.
+
+- [ ] **Step 1: Failing tests ergänzen**
+
+In `tests/test_produkt_repo.py` ergänzen:
+
+```python
+def test_aktion_setzen_und_laden(db):
+    from app.repositories.produkt_repo import aktion_setzen, produkt_laden
+
+    aktion_setzen(
+        db, 2, aktionspreis_chf=12.0, aktionstext="MHD 09/2026",
+        aktion_von="2026-06-01", aktion_bis="2026-06-30",
+    )
+    p = produkt_laden(db, 2)
+    assert p["aktionspreis_chf"] == 12.0
+    assert p["aktionstext"] == "MHD 09/2026"
+    assert p["aktion_von"] == "2026-06-01"
+    assert p["aktion_bis"] == "2026-06-30"
+
+
+def test_aktion_entfernen_setzt_null(db):
+    from app.repositories.produkt_repo import aktion_entfernen, aktion_setzen, produkt_laden
+
+    aktion_setzen(db, 2, aktionspreis_chf=12.0, aktionstext="x",
+                  aktion_von=None, aktion_bis=None)
+    aktion_entfernen(db, 2)
+    p = produkt_laden(db, 2)
+    assert p["aktionspreis_chf"] is None
+    assert p["aktionstext"] is None
+    assert p["aktion_von"] is None
+    assert p["aktion_bis"] is None
+
+
+def test_alle_produkte_admin_enthaelt_alle(db):
+    from app.repositories.produkt_repo import alle_produkte_admin
+
+    produkte = alle_produkte_admin(db)
+    assert len(produkte) == 3
+    assert produkte[0]["menge_ml"] <= produkte[-1]["menge_ml"]
+```
+
+- [ ] **Step 2: Tests laufen lassen — müssen fehlschlagen**
+
+Run: `uv run pytest tests/test_produkt_repo.py -v`
+Expected: FAIL.
+
+- [ ] **Step 3: Repo-Funktionen ergänzen**
+
+In `app/repositories/produkt_repo.py` ans Dateiende anhängen:
+
+```python
+def alle_produkte_admin(conn: sqlite3.Connection) -> list[dict]:
+    rows = conn.execute(
+        "SELECT id, name, menge_ml, preis_chf, beschreibung, bild_pfad, aktiv, "
+        "aktionspreis_chf, aktionstext, aktion_von, aktion_bis "
+        "FROM produkte ORDER BY menge_ml"
+    ).fetchall()
+    return [dict(row) for row in rows]
+
+
+def produkt_laden(conn: sqlite3.Connection, produkt_id: int) -> dict | None:
+    row = conn.execute(
+        "SELECT id, name, menge_ml, preis_chf, beschreibung, bild_pfad, aktiv, "
+        "aktionspreis_chf, aktionstext, aktion_von, aktion_bis "
+        "FROM produkte WHERE id = ?",
+        (produkt_id,),
+    ).fetchone()
+    return dict(row) if row else None
+
+
+def aktion_setzen(
+    conn: sqlite3.Connection,
+    produkt_id: int,
+    *,
+    aktionspreis_chf: float,
+    aktionstext: str,
+    aktion_von: str | None,
+    aktion_bis: str | None,
+) -> None:
+    conn.execute(
+        "UPDATE produkte SET aktionspreis_chf = ?, aktionstext = ?, "
+        "aktion_von = ?, aktion_bis = ? WHERE id = ?",
+        (aktionspreis_chf, aktionstext, aktion_von or None, aktion_bis or None, produkt_id),
+    )
+    conn.commit()
+
+
+def aktion_entfernen(conn: sqlite3.Connection, produkt_id: int) -> None:
+    conn.execute(
+        "UPDATE produkte SET aktionspreis_chf = NULL, aktionstext = NULL, "
+        "aktion_von = NULL, aktion_bis = NULL WHERE id = ?",
+        (produkt_id,),
+    )
+    conn.commit()
+```
+
+- [ ] **Step 4: Tests laufen lassen — müssen bestehen**
+
+Run: `uv run pytest tests/test_produkt_repo.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/repositories/produkt_repo.py tests/test_produkt_repo.py
+git commit -m "feat: Admin-Repo für Produkt-Aktionen (#134)"
+```
+
+---
+
+### Task 9: Admin-UI für Aktionen (Router, Templates, Navigation)
+
+Liste der Produkte mit Aktions-Status, Formular zum Setzen/Entfernen, mit Validierung (`aktionspreis < preis_chf`), CSRF-Schutz und Audit-Log.
+
+**Files:**
+- Create: `app/routers/produkt_admin.py`
+- Create: `templates/admin/produkte.html`
+- Create: `templates/admin/produkt_aktion_form.html`
+- Modify: `app/main.py` (Router registrieren)
+- Modify: `templates/admin/base.html` (Nav-Link)
+- Test: `tests/test_api_produkt_admin.py` (neu)
+
+**Interfaces:**
+- Consumes: `alle_produkte_admin`, `produkt_laden`, `aktion_setzen`, `aktion_entfernen` (Task 8); `log_eintrag_schreiben`; `require_csrf`, `admin_identity`, `generiere_csrf_token`; `validate_session`.
+- Produces: Routen `GET /admin/produkte`, `GET /admin/produkte/{id}/aktion`, `POST /admin/produkte/{id}/aktion`.
+
+- [ ] **Step 1: Failing tests schreiben**
+
+`tests/test_api_produkt_admin.py`:
+
+```python
+def _make_admin_client(tmp_path, monkeypatch):
+    import bcrypt
+    from fastapi.testclient import TestClient
+
+    pw_hash = bcrypt.hashpw(b"testpass", bcrypt.gensalt()).decode()
+    monkeypatch.setattr(
+        "app.config.settings.database_path", str(tmp_path / "admin_test.db")
+    )
+    monkeypatch.setattr("app.config.settings.admin_credentials", f"dev:{pw_hash}")
+    monkeypatch.setattr("app.config.settings.cookie_secure", False)
+    from app.database import init_db
+
+    init_db()
+    from app.main import app
+
+    return TestClient(app)
+
+
+def _admin_login(admin_client):
+    from app.config import settings
+    from app.csrf import generiere_csrf_token
+
+    get_resp = admin_client.get("/admin/login")
+    csrf_id = get_resp.cookies.get("csrf_id", "")
+    csrf = generiere_csrf_token(settings.secret_key, identity=f"anon:{csrf_id}")
+    resp = admin_client.post(
+        "/admin/login",
+        data={"password": "testpass", "csrf_token": csrf},
+        follow_redirects=False,
+    )
+    return resp.cookies
+
+
+def _csrf_fuer_session(cookies):
+    from app.config import settings
+    from app.csrf import admin_identity, generiere_csrf_token
+
+    return generiere_csrf_token(
+        settings.secret_key, identity=admin_identity(cookies.get("admin_session"))
+    )
+
+
+def test_admin_produkte_liste(tmp_path, monkeypatch):
+    admin_client = _make_admin_client(tmp_path, monkeypatch)
+    admin_client.cookies = _admin_login(admin_client)
+    resp = admin_client.get("/admin/produkte")
+    assert resp.status_code == 200
+    assert "Olivenöl 750ml" in resp.text
+
+
+def test_admin_aktion_setzen(tmp_path, monkeypatch):
+    admin_client = _make_admin_client(tmp_path, monkeypatch)
+    cookies = _admin_login(admin_client)
+    admin_client.cookies = cookies
+    csrf = _csrf_fuer_session(cookies)
+    resp = admin_client.post(
+        "/admin/produkte/2/aktion",
+        data={
+            "aktionspreis_chf": "12.00", "aktionstext": "MHD 09/2026",
+            "aktion_von": "", "aktion_bis": "", "csrf_token": csrf,
+        },
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+    from app.database import get_db
+
+    conn = get_db()
+    row = conn.execute(
+        "SELECT aktionspreis_chf, aktionstext FROM produkte WHERE id = 2"
+    ).fetchone()
+    conn.close()
+    assert row["aktionspreis_chf"] == 12.0
+    assert row["aktionstext"] == "MHD 09/2026"
+
+
+def test_admin_aktion_groesser_als_preis_abgelehnt(tmp_path, monkeypatch):
+    admin_client = _make_admin_client(tmp_path, monkeypatch)
+    cookies = _admin_login(admin_client)
+    admin_client.cookies = cookies
+    csrf = _csrf_fuer_session(cookies)
+    resp = admin_client.post(
+        "/admin/produkte/2/aktion",
+        data={
+            "aktionspreis_chf": "20.00", "aktionstext": "zu teuer",
+            "aktion_von": "", "aktion_bis": "", "csrf_token": csrf,
+        },
+        follow_redirects=False,
+    )
+    assert resp.status_code == 400
+    from app.database import get_db
+
+    conn = get_db()
+    row = conn.execute("SELECT aktionspreis_chf FROM produkte WHERE id = 2").fetchone()
+    conn.close()
+    assert row["aktionspreis_chf"] is None
+
+
+def test_admin_aktion_entfernen(tmp_path, monkeypatch):
+    admin_client = _make_admin_client(tmp_path, monkeypatch)
+    cookies = _admin_login(admin_client)
+    admin_client.cookies = cookies
+    csrf = _csrf_fuer_session(cookies)
+    # erst setzen
+    admin_client.post(
+        "/admin/produkte/2/aktion",
+        data={"aktionspreis_chf": "12.00", "aktionstext": "x",
+              "aktion_von": "", "aktion_bis": "", "csrf_token": csrf},
+        follow_redirects=False,
+    )
+    # dann leerer Aktionspreis = entfernen
+    resp = admin_client.post(
+        "/admin/produkte/2/aktion",
+        data={"aktionspreis_chf": "", "aktionstext": "",
+              "aktion_von": "", "aktion_bis": "", "csrf_token": csrf},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+    from app.database import get_db
+
+    conn = get_db()
+    row = conn.execute("SELECT aktionspreis_chf FROM produkte WHERE id = 2").fetchone()
+    conn.close()
+    assert row["aktionspreis_chf"] is None
+
+
+def test_admin_produkte_ohne_login_redirect(tmp_path, monkeypatch):
+    admin_client = _make_admin_client(tmp_path, monkeypatch)
+    resp = admin_client.get("/admin/produkte", follow_redirects=False)
+    assert resp.status_code == 303
+```
+
+- [ ] **Step 2: Tests laufen lassen — müssen fehlschlagen**
+
+Run: `uv run pytest tests/test_api_produkt_admin.py -v`
+Expected: FAIL (Routen fehlen).
+
+- [ ] **Step 3: Router implementieren**
+
+`app/routers/produkt_admin.py`:
+
+```python
+from fastapi import APIRouter, Cookie, Depends, Form, HTTPException, Request
+from fastapi.responses import RedirectResponse
+
+from app.config import settings
+from app.csrf import admin_identity, generiere_csrf_token, require_csrf
+from app.database import get_db
+from app.repositories.admin_repo import log_eintrag_schreiben
+from app.repositories.produkt_repo import (
+    aktion_entfernen,
+    aktion_setzen,
+    alle_produkte_admin,
+    produkt_laden,
+)
+from app.services.auth_service import validate_session
+from app.templating import templates
+
+router = APIRouter()
+
+
+def _get_admin_label(admin_session: str | None) -> str | None:
+    if not admin_session:
+        return None
+    return validate_session(
+        admin_session,
+        secret=settings.secret_key,
+        max_age=settings.admin_session_max_age,
+    )
+
+
+@router.get("/admin/produkte")
+def admin_produkte_liste(request: Request, admin_session: str | None = Cookie(None)):
+    label = _get_admin_label(admin_session)
+    if not label:
+        return RedirectResponse("/admin/login", status_code=303)
+    conn = get_db()
+    try:
+        produkte = alle_produkte_admin(conn)
+    finally:
+        conn.close()
+    csrf = generiere_csrf_token(
+        settings.secret_key, identity=admin_identity(admin_session or "")
+    )
+    return templates.TemplateResponse(
+        request,
+        "admin/produkte.html",
+        {"admin_label": label, "csrf_token": csrf, "produkte": produkte},
+    )
+
+
+@router.get("/admin/produkte/{produkt_id}/aktion")
+def admin_aktion_formular(
+    request: Request, produkt_id: int, admin_session: str | None = Cookie(None)
+):
+    label = _get_admin_label(admin_session)
+    if not label:
+        return RedirectResponse("/admin/login", status_code=303)
+    conn = get_db()
+    try:
+        produkt = produkt_laden(conn, produkt_id)
+    finally:
+        conn.close()
+    if not produkt:
+        return RedirectResponse("/admin/produkte", status_code=303)
+    csrf = generiere_csrf_token(
+        settings.secret_key, identity=admin_identity(admin_session or "")
+    )
+    return templates.TemplateResponse(
+        request,
+        "admin/produkt_aktion_form.html",
+        {"admin_label": label, "csrf_token": csrf, "produkt": produkt},
+    )
+
+
+@router.post("/admin/produkte/{produkt_id}/aktion", dependencies=[Depends(require_csrf)])
+def admin_aktion_speichern(
+    request: Request,
+    produkt_id: int,
+    aktionspreis_chf: str = Form(""),
+    aktionstext: str = Form(""),
+    aktion_von: str = Form(""),
+    aktion_bis: str = Form(""),
+    csrf_token: str = Form(""),
+    admin_session: str | None = Cookie(None),
+):
+    label = _get_admin_label(admin_session)
+    if not label:
+        return RedirectResponse("/admin/login", status_code=303)
+    conn = get_db()
+    try:
+        produkt = produkt_laden(conn, produkt_id)
+        if not produkt:
+            raise HTTPException(404, "Produkt nicht gefunden")
+        if not aktionspreis_chf.strip():
+            aktion_entfernen(conn, produkt_id)
+            log_eintrag_schreiben(
+                conn, admin_label=label, aktion="aktion_entfernt",
+                details=produkt["name"],
+            )
+        else:
+            preis = float(aktionspreis_chf)
+            if preis <= 0 or preis >= produkt["preis_chf"]:
+                raise HTTPException(
+                    400, "Aktionspreis muss grösser als 0 und kleiner als der "
+                    "Normalpreis sein.",
+                )
+            aktion_setzen(
+                conn, produkt_id,
+                aktionspreis_chf=preis,
+                aktionstext=aktionstext.strip(),
+                aktion_von=aktion_von.strip() or None,
+                aktion_bis=aktion_bis.strip() or None,
+            )
+            log_eintrag_schreiben(
+                conn, admin_label=label, aktion="aktion_gesetzt",
+                details=f"{produkt['name']}: CHF {preis:.2f}",
+            )
+    finally:
+        conn.close()
+    return RedirectResponse("/admin/produkte", status_code=303)
+```
+
+- [ ] **Step 4: Router registrieren**
+
+In `app/main.py`: in den `from app.routers import (...)`-Block `produkt_admin` ergänzen und nach `app.include_router(rabattcodes.router)` einfügen:
+
+```python
+app.include_router(produkt_admin.router)
+```
+
+- [ ] **Step 5: Listen-Template anlegen**
+
+`templates/admin/produkte.html`:
+
+```html
+{% extends "admin/base.html" %}
+{% block title %}Aktionspreise{% endblock %}
+{% block content %}
+<h1 class="font-display text-5xl font-bold text-accent mb-8">Aktionspreise</h1>
+<div class="flex flex-col gap-3">
+    {% for p in produkte %}
+    <div class="bg-stone-700 rounded-lg p-4 shadow-md flex items-center justify-between gap-4">
+        <div>
+            <div class="font-semibold">{{ p.name }}</div>
+            <div class="text-stone-400 text-sm">
+                Normalpreis: CHF {{ "%.2f"|format(p.preis_chf) }}
+                {% if p.aktionspreis_chf %}
+                — <span class="text-accent">Aktion: CHF {{ "%.2f"|format(p.aktionspreis_chf) }}</span>
+                {% if p.aktion_von or p.aktion_bis %}
+                ({{ p.aktion_von or "…" }} – {{ p.aktion_bis or "…" }})
+                {% endif %}
+                {% endif %}
+            </div>
+        </div>
+        <a href="/admin/produkte/{{ p.id }}/aktion"
+           class="bg-accent text-stone-900 px-4 py-2 rounded font-bold hover:bg-yellow-400 transition-colors whitespace-nowrap">
+            {{ "Aktion bearbeiten" if p.aktionspreis_chf else "Aktion setzen" }}
+        </a>
+    </div>
+    {% endfor %}
+</div>
+{% endblock %}
+```
+
+- [ ] **Step 6: Formular-Template anlegen**
+
+`templates/admin/produkt_aktion_form.html`:
+
+```html
+{% extends "admin/base.html" %}
+{% block title %}Aktion: {{ produkt.name }}{% endblock %}
+{% block content %}
+<a href="/admin/produkte" class="text-stone-400 hover:text-accent text-sm transition-colors">&larr; Zurück</a>
+<h1 class="font-display text-5xl font-bold text-accent mt-4 mb-2">Aktion: {{ produkt.name }}</h1>
+<p class="text-stone-400 mb-8">Normalpreis: CHF {{ "%.2f"|format(produkt.preis_chf) }}</p>
+<form method="post" class="max-w-lg space-y-6">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+    <div class="bg-stone-700 rounded-lg p-6 shadow-md space-y-4">
+        <div>
+            <label class="block text-stone-400 text-sm mb-1">Aktionspreis CHF <span class="text-stone-500">(leer = Aktion entfernen)</span></label>
+            <input type="number" name="aktionspreis_chf" step="0.01" min="0"
+                   value="{{ produkt.aktionspreis_chf if produkt.aktionspreis_chf else '' }}"
+                   class="w-full bg-stone-800 border border-stone-600 rounded px-3 py-2">
+        </div>
+        <div>
+            <label class="block text-stone-400 text-sm mb-1">Begründungstext</label>
+            <input type="text" name="aktionstext" maxlength="200"
+                   value="{{ produkt.aktionstext or '' }}"
+                   placeholder="z.B. Mindesthaltbarkeit 09/2026"
+                   class="w-full bg-stone-800 border border-stone-600 rounded px-3 py-2">
+        </div>
+        <div class="grid grid-cols-2 gap-4">
+            <div>
+                <label class="block text-stone-400 text-sm mb-1">Gültig von <span class="text-stone-500">(optional)</span></label>
+                <input type="date" name="aktion_von" value="{{ produkt.aktion_von or '' }}"
+                       class="w-full bg-stone-800 border border-stone-600 rounded px-3 py-2">
+            </div>
+            <div>
+                <label class="block text-stone-400 text-sm mb-1">Gültig bis <span class="text-stone-500">(optional)</span></label>
+                <input type="date" name="aktion_bis" value="{{ produkt.aktion_bis or '' }}"
+                       class="w-full bg-stone-800 border border-stone-600 rounded px-3 py-2">
+            </div>
+        </div>
+    </div>
+    <button type="submit"
+            class="w-full bg-accent text-stone-900 py-3 rounded font-bold text-lg hover:bg-yellow-400 transition-colors">
+        Speichern
+    </button>
+</form>
+{% endblock %}
+```
+
+- [ ] **Step 7: Nav-Link ergänzen**
+
+In `templates/admin/base.html` nach dem Rabattcodes-Link (Zeile mit `href="/admin/rabattcodes"`) einfügen:
+
+```html
+                <a href="/admin/produkte" class="text-stone-400 hover:text-accent text-sm transition-colors ml-4">Aktionspreise</a>
+```
+
+- [ ] **Step 8: Tests laufen lassen — müssen bestehen**
+
+Run: `uv run pytest tests/test_api_produkt_admin.py -v`
+Expected: PASS (6 Tests).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add app/routers/produkt_admin.py app/main.py templates/admin/produkte.html templates/admin/produkt_aktion_form.html templates/admin/base.html tests/test_api_produkt_admin.py
+git commit -m "feat: Admin-UI für produktbezogene Aktionspreise (#134)"
+```
+
+---
+
+### Task 10: Dokumentation
+
+arc42 und user-stories-testplan aktualisieren.
+
+**Files:**
+- Modify: `docs/arc42.md`
+- Modify: `docs/user-stories-testplan.md`
+
+**Interfaces:** keine (Doku).
+
+- [ ] **Step 1: arc42 ergänzen**
+
+In `docs/arc42.md` einen kurzen Abschnitt zur Aktionspreis-Mechanik ergänzen: zentrale Funktion `effektiver_preis()` als einzige Preisautorität; Spalten an `produkte`; Abgrenzung zu Rabattcodes (Einzelpreis- vs. Warenkorb-Ebene); Regel „Rabattcode nur auf Nicht-Aktions-Anteil". An die bestehende Struktur/Überschriftenebene des Dokuments anpassen.
+
+- [ ] **Step 2: user-stories-testplan ergänzen**
+
+In `docs/user-stories-testplan.md` eine User Story + Testfälle ergänzen:
+- Als SH kann ich einem Produkt einen befristeten Aktionspreis mit Begründungstext geben.
+- Testfälle: Aktion sichtbar auf Produktkarte (Badge, durchgestrichen, −%, Text); Bestellung rechnet mit Aktionspreis; Rabattcode nur auf Nicht-Aktionsanteil; reiner Aktions-Warenkorb lehnt Code ab; Aktion läuft nach `aktion_bis` automatisch aus.
+An Format und Nummerierung der bestehenden Einträge anpassen.
+
+- [ ] **Step 3: Vollständige Test-Suite + Lint**
+
+Run: `uv run pytest -q && ruff check .`
+Expected: alle Tests grün, keine Lint-Fehler.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/arc42.md docs/user-stories-testplan.md
+git commit -m "docs: Aktionspreise in arc42 und user-stories-testplan (#134)"
+```
+
+---
+
+## Self-Review
+
+**Spec-Abdeckung:**
+- AK „Aktionspreis + Begründungstext, optional, mit Zeitraum" → Tasks 1, 2, 8, 9. ✔
+- AK „Produktkarte zeigt durchgestrichen/Aktion/Badge/%/Text" → Task 6. ✔
+- AK „Warenkorb, Total, Stripe, Mails rechnen mit Aktionspreis" → Task 4 (zentral via `berechne_total`, daher Stripe/DB/Mails/QR automatisch). ✔
+- AK „Verhalten ohne Aktion unverändert" → Task 4/6 (bestehende Tests bleiben grün), explizit getestet. ✔
+- AK „Tests: mit/ohne Aktionspreis, Gültigkeits-Grenzfälle" → Tasks 2, 4, 5. ✔
+- AK „Doku aktualisiert" → Task 10. ✔
+- Entscheid „Rabattcode nur auf Nicht-Aktions-Anteil" → Tasks 4, 5, 7. ✔
+- Entscheid „Admin Self-Service" → Tasks 8, 9. ✔
+- Entscheid „Prozent berechnet" → Task 2. ✔
+
+**Platzhalter-Scan:** Keine TBD/TODO; alle Code-Schritte enthalten vollständigen Code. Task 10 beschreibt Doku-Inhalte prosaisch (kein Code nötig), referenziert konkrete Inhalte. ✔
+
+**Typ-Konsistenz:** `effektiver_preis(preis_chf, aktionspreis_chf, aktion_von, aktion_bis, heute)` identisch in Tasks 2, 4, 6 verwendet. `EffektivPreis`-Felder (`preis, ist_aktion, original_preis, prozent`) konsistent. Positions-Dict-Keys (`einzelpreis_chf, ist_aktion, original_preis_chf`) konsistent zwischen Tasks 4 und 5. Repo-Funktionsnamen (`aktion_setzen, aktion_entfernen, produkt_laden, alle_produkte_admin`) konsistent zwischen Tasks 8 und 9. ✔

--- a/docs/superpowers/specs/2026-06-23-aktionspreise-design.md
+++ b/docs/superpowers/specs/2026-06-23-aktionspreise-design.md
@@ -32,9 +32,11 @@ DB-Positionen, Bestätigungs-/Rechnungs-Mails und QR-Rechnung. Fliesst der Aktio
 als `einzelpreis_chf` ein, zieht er sich automatisch korrekt durch die gesamte Bestellkette.
 Der Warenkorb im Browser (localStorage) dient nur der Anzeige; der Server rechnet alles neu.
 
-## 1. Datenmodell — Migration `004_aktionspreise.sql`
+## 1. Datenmodell — Spalten an `produkte`
 
-Vier NULL-bare Spalten an `produkte`:
+Vier NULL-bare Spalten an `produkte`. Umgesetzt über `_add_column_if_not_exists()`
+in `init_db()` (idempotentes Projekt-Muster für Spalten an bestehenden Tabellen) —
+**nicht** über eine `ALTER TABLE`-Migrationsdatei (würde beim Re-Run scheitern):
 
 | Spalte | Typ | Bedeutung |
 |---|---|---|
@@ -125,7 +127,7 @@ Tailwind-Klassen gemäss bestehender Card-UI-Konvention (siehe lokale `CLAUDE.md
 
 | Bereich | Datei(en) |
 |---|---|
-| Migration | `migrations/004_aktionspreise.sql` (neu) |
+| DB-Spalten | `app/database.py` (`_add_column_if_not_exists` in `init_db`), `tests/conftest.py` (`db`-Fixture) |
 | Effektiv-Preis | `app/services/aktions_service.py` (neu) |
 | Model | `app/models.py` (`Produkt` um Aktions-Felder) |
 | Repo | `app/repositories/produkt_repo.py` |

--- a/docs/superpowers/specs/2026-06-23-aktionspreise-design.md
+++ b/docs/superpowers/specs/2026-06-23-aktionspreise-design.md
@@ -1,0 +1,146 @@
+# Produktbezogene Aktionspreise — Design
+
+> GitHub Issue: #134 (feat, phase-4)
+> Datum: 2026-06-23
+
+## Ziel
+
+Der Stakeholder (SH) soll **einzelne Produkte temporär rabattiert** anbieten können —
+z. B. Flaschen mit nahender Mindesthaltbarkeit. Der Aktionspreis ist direkt auf der
+Produktkarte sichtbar (durchgestrichener Originalpreis, Aktionspreis, RABATT-Badge,
+Prozent-Ersparnis, Begründungstext), **ohne dass der Kunde einen Code eingeben muss**.
+
+Abgrenzung: Dies ist eine **andere Mechanik** als die bestehenden Rabattcodes
+(`rabattcode_service.py`, Coupon auf Warenkorb-Ebene). Aktionspreise wirken auf den
+**Einzelpreis** eines Produkts.
+
+## Entscheidungen (aus Brainstorming)
+
+| Frage | Entscheid |
+|---|---|
+| Pflege | **Admin-UI (Self-Service)** — SH setzt Aktion selbst, analog `rabattcode_form` |
+| Datenmodell | **Spalten an `produkte`** (eine Aktion pro Produkt), kein separates Table |
+| Gültigkeit | **von/bis optional, auto-ablaufend** — leer = unbegrenzt; nach `aktion_bis` automatisch Normalpreis |
+| Rabattcode-Stacking | **Code gilt nur für Nicht-Aktions-Anteil** des Warenkorbs |
+| Prozent-Badge | **berechnet** (`round((1 − aktion/original)·100)`), keine extra Spalte |
+| Mails/Rechnung | Zeigen den korrekten reduzierten Betrag, **ohne** extra „du hast X gespart"-Zeile |
+
+## Architektur-Kernprinzip
+
+`berechne_total()` ist die **einzige autoritative Preisquelle** für Bestellung, Stripe,
+DB-Positionen, Bestätigungs-/Rechnungs-Mails und QR-Rechnung. Fliesst der Aktionspreis dort
+als `einzelpreis_chf` ein, zieht er sich automatisch korrekt durch die gesamte Bestellkette.
+Der Warenkorb im Browser (localStorage) dient nur der Anzeige; der Server rechnet alles neu.
+
+## 1. Datenmodell — Migration `004_aktionspreise.sql`
+
+Vier NULL-bare Spalten an `produkte`:
+
+| Spalte | Typ | Bedeutung |
+|---|---|---|
+| `aktionspreis_chf` | REAL NULL | reduzierter Preis; NULL = keine Aktion |
+| `aktionstext` | TEXT NULL | Begründung („Mindesthaltbarkeit 09/2026 …") |
+| `aktion_von` | TEXT NULL | ISO-Datum (`YYYY-MM-DD`), leer = sofort gültig |
+| `aktion_bis` | TEXT NULL | ISO-Datum, leer = unbegrenzt gültig |
+
+**Aktion aktiv** ⇔ `aktionspreis_chf IS NOT NULL`
+**und** (`aktion_von` leer **oder** heute ≥ `aktion_von`)
+**und** (`aktion_bis` leer **oder** heute ≤ `aktion_bis`).
+
+Nach `aktion_bis` greift automatisch wieder `preis_chf` — keine manuelle Deaktivierung nötig.
+
+## 2. Effektiv-Preis als zentrale Logik
+
+Neue Funktion in einem `app/services/aktions_service.py`:
+
+```
+effektiver_preis(produkt_row, heute) -> EffektivPreis
+# liefert: preis, ist_aktion (bool), original_preis, prozent (int, gerundet)
+```
+
+Dies ist die **einzige** Stelle, die entscheidet, welcher Preis gilt. Alle Konsumenten rufen sie auf:
+
+- **`berechne_total()`**: SELECT um die vier Aktions-Spalten erweitern; `einzelpreis_chf` =
+  Effektiv-Preis. Jede zurückgegebene Position trägt zusätzlich `ist_aktion: bool`.
+  → Stripe, DB-Positionen, Mails und QR-Rechnung rechnen automatisch mit dem Aktionspreis.
+- **`get_alle_produkte()` / `Produkt`-Model**: Aktions-Felder mitliefern (optional, NULL-bar),
+  damit die Produktkarte den Original- und Aktionspreis, Prozent und Text anzeigen kann.
+
+Prozent-Ersparnis wird berechnet, nicht gespeichert.
+
+## 3. Rabattcode-Zusammenspiel (nur Nicht-Aktions-Anteil)
+
+`berechne_total()` markiert jede Position mit `ist_aktion`. Daraus ergibt sich der
+**rabattfähige Subtotal** = Summe der Nicht-Aktions-Positionen.
+
+- **Server (autoritativ, `bestellungen.py`)**: `pruefe_rabattcode(..., rabattfähiger_subtotal)`
+  statt `total`. Stripe-Coupon `amount_off` bezieht sich damit nur auf Nicht-Aktionsware.
+  Der Mindestbestellwert-Check im Rabattcode bezieht sich ebenfalls auf den rabattfähigen Subtotal.
+- **Live-Vorschau (`checkout.html` + `/api/rabattcode/pruefen`)**: Warenkorb-Items bekommen ein
+  `aktion`-Flag (gesetzt beim `addToCart` aus einem Data-Attribut). Der Client sendet den
+  Nicht-Aktions-Subtotal an die Vorschau-API. Konsistent mit der bestehenden Vorschau-Architektur
+  (Client liefert Subtotal, der Server bleibt bei Bestellabschluss die finale Autorität).
+- **Reiner Aktions-Warenkorb** → rabattfähiger Subtotal = 0 → Code greift nicht, klare Meldung
+  (z. B. „Auf Aktionsprodukte ist kein zusätzlicher Rabattcode möglich.").
+
+## 4. Admin-UI (Self-Service)
+
+Analog zum bestehenden Rabattcode-Bereich (`templates/admin/rabattcode_form.html`,
+`app/routers/rabattcodes.py`):
+
+- Liste „Produkte" im Admin-Bereich mit aktuellem (Aktions-)Status.
+- Bearbeiten-Formular pro Produkt: Aktionspreis, Aktionstext, von/bis setzen oder entfernen.
+- **Validierung**: Aktionspreis muss kleiner als `preis_chf` sein; sonst Fehlermeldung.
+- Audit-Log-Eintrag (`log_eintrag_schreiben`) wie bei Rabattcodes.
+- CSRF-Schutz analog bestehender Admin-Formulare.
+
+## 5. Frontend-Anzeige (Produktkarte, `templates/produkte.html`)
+
+Bei aktiver Aktion:
+- **RABATT**-Badge
+- durchgestrichener Originalpreis (`CHF 18.00`)
+- grosser Aktionspreis (`CHF 12.00`)
+- Prozent-Badge (`−33%`)
+- Begründungstext (`aktionstext`)
+- `data-product-price` trägt den **Aktionspreis** → Warenkorb, Flyout und Checkout-Vorschau
+  zeigen automatisch den reduzierten Preis.
+
+Ohne aktive Aktion: Darstellung unverändert (kein Badge, `preis_chf` wie bisher).
+Tailwind-Klassen gemäss bestehender Card-UI-Konvention (siehe lokale `CLAUDE.md`).
+
+## 6. Tests & Dokumentation
+
+**Tests (pytest):**
+- `effektiver_preis`: Grenzfälle — kein Aktionspreis, von/bis leer, vor `aktion_von`,
+  nach `aktion_bis`, innerhalb Zeitraum, nur `von` gesetzt, nur `bis` gesetzt.
+- `berechne_total`: mit/ohne Aktion; `einzelpreis_chf` und `ist_aktion` korrekt.
+- Rabattcode-Ausschluss: gemischter Warenkorb (Code nur auf Nicht-Aktionsanteil),
+  reiner Aktions-Warenkorb (Code greift nicht).
+
+**Doku:**
+- `docs/arc42.md` — Aktionspreis-Mechanik und Abgrenzung zu Rabattcodes.
+- `docs/user-stories-testplan.md` — User Story + Testfälle ergänzen.
+
+## Betroffene Dateien (Übersicht)
+
+| Bereich | Datei(en) |
+|---|---|
+| Migration | `migrations/004_aktionspreise.sql` (neu) |
+| Effektiv-Preis | `app/services/aktions_service.py` (neu) |
+| Model | `app/models.py` (`Produkt` um Aktions-Felder) |
+| Repo | `app/repositories/produkt_repo.py` |
+| Bestelllogik | `app/services/bestell_service.py` (`berechne_total`) |
+| Bestell-Route | `app/routers/bestellungen.py` (rabattfähiger Subtotal) |
+| Rabattcode-Vorschau | `app/routers/rabattcodes.py`, `templates/checkout.html` |
+| Warenkorb-JS | `static/js/cart.js` (`aktion`-Flag) |
+| Admin-UI | `app/routers/` + `templates/admin/` (neu/erweitert) |
+| Produktkarte | `templates/produkte.html` |
+| Tests | `tests/` |
+| Doku | `docs/arc42.md`, `docs/user-stories-testplan.md` |
+
+## YAGNI / bewusst weggelassen
+
+- Kein Aktions-Verlauf / mehrere geplante Aktionen pro Produkt (separate Tabelle) — eine
+  aktive Aktion pro Produkt genügt für den Anlass.
+- Keine manuelle Prozent-Eingabe — wird berechnet.
+- Keine „du hast X gespart"-Zeile in Mails — der reduzierte Betrag genügt.

--- a/docs/superpowers/specs/2026-06-23-seed-aktion-persistenz-design.md
+++ b/docs/superpowers/specs/2026-06-23-seed-aktion-persistenz-design.md
@@ -1,0 +1,80 @@
+# Design: Seed überschreibt Admin-Aktionen nicht mehr (Bug #137, Fix zu #134)
+
+> Status: genehmigt 2026-06-23 · Bug #137 · wird auf `feat/134-aktionspreise` vor dem Merge umgesetzt
+
+## Problem
+
+`init_db()` (`app/database.py`) führt bei **jedem** Container-Start alle Migrationen
+neu aus. Der Produkt-Seed in `migrations/001_initial.sql` nutzt dabei
+`INSERT OR REPLACE`, was die **gesamte** Produktzeile ersetzt.
+
+#134 hat der Tabelle `produkte` vier admin-editierbare Spalten hinzugefügt
+(`aktionspreis_chf`, `aktionstext`, `aktion_von`, `aktion_bis`), die der Inhaber
+über die Admin-Oberfläche setzt. Der Seed listet diese Spalten **nicht** auf →
+bei jedem Neustart fallen sie auf `NULL` zurück. **Eine im Admin gesetzte Aktion
+verschwindet damit stillschweigend** bei jedem Deploy, fly.io-Maschinenneustart
+oder Litestream-Restore.
+
+Der Fehler entsteht erst mit #134 (vorher hatte `produkte` keine
+admin-editierbaren Spalten) und war **nie in Produktion**, da #134 noch nicht
+gemerged ist.
+
+### Betroffene Spalten (Umfang)
+
+Einzige admin-editierbare Spalten auf `produkte` sind die 4 Aktions-Spalten
+(`aktion_setzen`/`aktion_entfernen` in `produkt_repo.py`). `aktiv` ist **nicht**
+admin-editierbar. Der Umfang ist damit exakt auf die 4 Aktions-Spalten begrenzt.
+
+## Entscheidung
+
+Option C (von drei evaluierten Ansätzen): **Seed als gezieltes UPSERT, das nur
+die Katalog-Spalten aktualisiert.**
+
+| Option | Kern | Bewertung |
+|---|---|---|
+| A — separate Tabelle `produkt_aktionen` | Aktions-Spalten aus `produkte` auslagern | Strukturell am saubersten, aber Umbau an #134; 1:1-Split für 4 Spalten over-normalisiert |
+| **C — UPSERT nur Katalog-Spalten** ⭐ | `ON CONFLICT(id) DO UPDATE` nur für Katalog | Kleinster Eingriff, kein #134-Umbau, Wurzel getroffen |
+| B — `INSERT OR IGNORE` | Seed aktualisiert existierende Zeilen nie | Grob: Katalog-Korrekturen per Migration greifen nicht mehr |
+
+Begründung C: KISS/YAGNI für ein kleines Projekt. Die Katalog-Spalten bleiben
+Git-/Migrations-verwaltet (Korrekturen greifen weiter bei jedem Boot), die
+Admin-Spalten bleiben unberührt. Kein Schema-Umbau, #134-Code unverändert.
+
+## Umsetzung
+
+### 1. `migrations/001_initial.sql`
+
+`INSERT OR REPLACE` → `INSERT … ON CONFLICT(id) DO UPDATE SET` mit ausschliesslich
+den Katalog-Spalten:
+
+```sql
+INSERT INTO produkte (id, name, menge_ml, preis_chf, beschreibung, bild_pfad) VALUES
+    (1, ...), (2, ...), (3, ...)
+ON CONFLICT(id) DO UPDATE SET
+    name         = excluded.name,
+    menge_ml     = excluded.menge_ml,
+    preis_chf    = excluded.preis_chf,
+    beschreibung = excluded.beschreibung,
+    bild_pfad    = excluded.bild_pfad;
+```
+
+Ein Kommentar warnt davor, künftige admin-editierbare Spalten hier aufzunehmen.
+
+### 2. Regressionstest (`tests/test_seed_aktion_persistenz.py`)
+
+`init_db()` → Aktion via `aktion_setzen` setzen → `init_db()` erneut (simuliert
+Neustart) → Aktion ist **weiterhin** gesetzt. Schützt die Wurzel dauerhaft.
+
+### 3. Dokumentation
+
+- `docs/arc42.md`: Seed-/Persistenz-Verhalten ergänzen, falls dort beschrieben.
+- `docs/user-stories-testplan.md`: Testfall „Aktion überlebt Neustart" ergänzen.
+- #134-Design-Spec: Querverweis auf diesen Fix.
+
+## Risiken / Trade-offs
+
+- **Disziplin-Footgun:** Jede künftige admin-editierbare Spalte muss bewusst aus
+  der UPSERT-Liste herausgehalten werden. Mitigation: Kommentar im Seed.
+- Verhalten für die Katalog-Spalten bleibt identisch (Korrekturen greifen bei
+  jedem Boot) — keine Verhaltensänderung für bestehende Produkte 1–3 ausser dem
+  Schutz der Aktions-Spalten.

--- a/docs/user-stories-testplan.md
+++ b/docs/user-stories-testplan.md
@@ -288,6 +288,7 @@
 | [ ] 10 | Checkout: Warenkorb nur mit Aktionsartikel (1x 250ml) und Rabattcode eingeben | Fehlermeldung "Code gilt nicht für Aktionsartikel" (oder sinngemäss) |
 | [ ] 11 | Admin: Aktionspreis entfernen | Produktkarte zeigt wieder Normalpreis CHF 8, kein Badge |
 | [ ] 12 | Admin: Aktionspreis mit `aktion_bis` = gestern setzen (abgelaufene Aktion) | Produktkarte zeigt sofort Normalpreis — Aktion automatisch abgelaufen |
+| [ ] 13 | Admin: Aktionspreis setzen, danach App neu deployen/neustarten (simuliert fly.io-Neustart) | Aktion ist nach dem Neustart **weiterhin gesetzt** — der Seed überschreibt sie nicht (Bug #137; automatisch abgedeckt durch `tests/test_seed_aktion_persistenz.py`) |
 
 ---
 

--- a/docs/user-stories-testplan.md
+++ b/docs/user-stories-testplan.md
@@ -270,6 +270,27 @@
 
 ---
 
+## Story 15: Aktionspreise
+
+**Als** Shopbetreiber möchte ich einem Produkt einen befristeten Aktionspreis mit Begründungstext geben, damit ich zeitlich begrenzte Angebote anbieten kann, ohne manuell eingreifen zu müssen.
+
+| Schritt | Aktion | Erwartetes Ergebnis |
+|---------|--------|---------------------|
+| [ ] 1 | Admin: `/admin/produkte` aufrufen | Produktliste mit "Aktionspreis setzen"-Formular je Produkt |
+| [ ] 2 | Admin: Für 250ml Flasche Aktionspreis CHF 6, Text "Frühlingsaktion", Zeitraum heute bis in 7 Tagen setzen | Erfolgsmeldung, Audit-Log-Eintrag sichtbar |
+| [ ] 3 | Startseite `/` aufrufen | 250ml-Karte zeigt: RABATT-Badge, durchgestrichener Originalpreis CHF 8, Aktionspreis CHF 6, –25%-Badge, Text "Frühlingsaktion" |
+| [ ] 4 | Warenkorb: 1x 250ml hinzufügen und Warenkorb öffnen | Einzelpreis CHF 6 (nicht CHF 8), Summe korrekt |
+| [ ] 5 | Checkout: Bestellung mit Aktionsprodukt abschicken (QR-Rechnung) | Bestätigungsseite zeigt CHF 6 pro 250ml |
+| [ ] 6 | E-Mail prüfen | Bestellbestätigung und QR-Rechnung enthalten Aktionspreis CHF 6 |
+| [ ] 7 | Admin: Bestelldetail prüfen | Bestellposition zeigt Einzelpreis CHF 6 |
+| [ ] 8 | Warenkorb: 1x 250ml (CHF 6, Aktionsartikel) + 1x 750ml (CHF 18, normal) | Rabattfähiger Subtotal = CHF 18 (nur 750ml) |
+| [ ] 9 | Checkout: Rabattcode (z. B. "SOMMER10", 10%) eingeben | Rabatt 10% auf CHF 18 = CHF 1.80; Aktionsartikel nicht rabattiert |
+| [ ] 10 | Checkout: Warenkorb nur mit Aktionsartikel (1x 250ml) und Rabattcode eingeben | Fehlermeldung "Code gilt nicht für Aktionsartikel" (oder sinngemäss) |
+| [ ] 11 | Admin: Aktionspreis entfernen | Produktkarte zeigt wieder Normalpreis CHF 8, kein Badge |
+| [ ] 12 | Admin: Aktionspreis mit `aktion_bis` = gestern setzen (abgelaufene Aktion) | Produktkarte zeigt sofort Normalpreis — Aktion automatisch abgelaufen |
+
+---
+
 ## Hinweise zum Testen
 
 - **Stripe-Testkarte:** `4242 4242 4242 4242`, beliebiges Ablaufdatum in der Zukunft, beliebige CVC

--- a/migrations/001_initial.sql
+++ b/migrations/001_initial.sql
@@ -41,7 +41,18 @@ CREATE TABLE IF NOT EXISTS bestellpositionen (
 );
 
 -- Seed: Olivalle-Produkte
-INSERT OR REPLACE INTO produkte (id, name, menge_ml, preis_chf, beschreibung, bild_pfad) VALUES
+-- UPSERT: init_db() laeuft bei jedem Container-Start. Beim Konflikt werden NUR
+-- die Katalog-Spalten aktualisiert. Die admin-editierbaren Aktions-Spalten
+-- (aktionspreis_chf, aktionstext, aktion_von, aktion_bis) sind bewusst NICHT
+-- gelistet, damit im Admin gesetzte Aktionen einen Neustart ueberleben (Bug #137).
+-- ACHTUNG: Kuenftige admin-editierbare Spalten hier ebenfalls NICHT auffuehren.
+INSERT INTO produkte (id, name, menge_ml, preis_chf, beschreibung, bild_pfad) VALUES
     (1, 'Olivenöl 250ml', 250, 8.00, 'Die kleine Flasche ist ideal zum Kennenlernen, als Geschenk oder für Feinkostläden, die Olivalle ins Sortiment aufnehmen möchten.', 'products/olivalle-250ml.jpeg'),
     (2, 'Olivenöl 750ml', 750, 18.00, 'Der Klassiker für den täglichen Gebrauch in der Küche. Ob zum Verfeinern von Salaten, zum Braten oder einfach mit frischem Brot — diese Flasche gehört auf jeden Tisch. Auch beliebt bei Restaurants und Betrieben.', 'products/olivalle-750ml.jpeg'),
-    (3, 'Olivenöl 3l Kanister', 3000, 50.00, 'Für Liebhaber, die nicht genug bekommen, und für Gastronomiebetriebe, die auf Qualität setzen: Der Kanister bietet das beste Preis-Leistungs-Verhältnis und reicht für den täglichen Einsatz.', 'products/olivalle-3l.jpeg');
+    (3, 'Olivenöl 3l Kanister', 3000, 50.00, 'Für Liebhaber, die nicht genug bekommen, und für Gastronomiebetriebe, die auf Qualität setzen: Der Kanister bietet das beste Preis-Leistungs-Verhältnis und reicht für den täglichen Einsatz.', 'products/olivalle-3l.jpeg')
+ON CONFLICT(id) DO UPDATE SET
+    name         = excluded.name,
+    menge_ml     = excluded.menge_ml,
+    preis_chf    = excluded.preis_chf,
+    beschreibung = excluded.beschreibung,
+    bild_pfad    = excluded.bild_pfad;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "olivalle"
-version = "1.2"
+version = "1.3"
 requires-python = ">=3.13"
 dependencies = [
     "fastapi>=0.115",

--- a/static/js/cart.js
+++ b/static/js/cart.js
@@ -9,13 +9,13 @@ function saveCart(cart) {
     updateCartCount();
 }
 
-function addToCart(id, name, price, image, buttonEl) {
+function addToCart(id, name, price, image, buttonEl, aktion) {
     const cart = getCart();
     const existing = cart.find((item) => item.produkt_id === id);
     if (existing) {
         existing.menge += 1;
     } else {
-        cart.push({ produkt_id: id, name: name, preis: price, image: image, menge: 1 });
+        cart.push({ produkt_id: id, name: name, preis: price, image: image, menge: 1, aktion: !!aktion });
     }
     saveCart(cart);
 
@@ -76,6 +76,10 @@ function updateCartCount() {
 
 function getCartTotal() {
     return getCart().reduce((sum, item) => sum + item.preis * item.menge, 0);
+}
+
+function getRabattSubtotal() {
+    return getCart().reduce((sum, item) => sum + (item.aktion ? 0 : item.preis * item.menge), 0);
 }
 
 function getVersandkosten(total) {
@@ -147,6 +151,7 @@ document.addEventListener("click", (e) => {
         btn.dataset.productName,
         parseFloat(btn.dataset.productPrice),
         btn.dataset.productImage,
-        btn
+        btn,
+        btn.dataset.productAktion === "1"
     );
 });

--- a/templates/admin/base.html
+++ b/templates/admin/base.html
@@ -17,6 +17,7 @@
                 <a href="/admin/" class="font-display text-4xl font-bold text-accent">Olivalle</a>
                 <span class="text-stone-400 text-sm border border-stone-600 rounded px-2 py-0.5">Admin</span>
                 <a href="/admin/rabattcodes" class="text-stone-400 hover:text-accent text-sm transition-colors ml-4">Rabattcodes</a>
+                <a href="/admin/produkte" class="text-stone-400 hover:text-accent text-sm transition-colors ml-4">Aktionspreise</a>
             </div>
             <div class="flex items-center gap-4 text-sm">
                 <span class="text-stone-400">{{ admin_label }}</span>

--- a/templates/admin/produkt_aktion_form.html
+++ b/templates/admin/produkt_aktion_form.html
@@ -1,0 +1,41 @@
+{% extends "admin/base.html" %}
+{% block title %}Aktion: {{ produkt.name }}{% endblock %}
+{% block content %}
+<a href="/admin/produkte" class="text-stone-400 hover:text-accent text-sm transition-colors">&larr; Zurück</a>
+<h1 class="font-display text-5xl font-bold text-accent mt-4 mb-2">Aktion: {{ produkt.name }}</h1>
+<p class="text-stone-400 mb-8">Normalpreis: CHF {{ "%.2f"|format(produkt.preis_chf) }}</p>
+<form method="post" class="max-w-lg space-y-6">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+    <div class="bg-stone-700 rounded-lg p-6 shadow-md space-y-4">
+        <div>
+            <label class="block text-stone-400 text-sm mb-1">Aktionspreis CHF <span class="text-stone-500">(leer = Aktion entfernen)</span></label>
+            <input type="number" name="aktionspreis_chf" step="0.01" min="0"
+                   value="{{ produkt.aktionspreis_chf if produkt.aktionspreis_chf else '' }}"
+                   class="w-full bg-stone-800 border border-stone-600 rounded px-3 py-2">
+        </div>
+        <div>
+            <label class="block text-stone-400 text-sm mb-1">Begründungstext</label>
+            <input type="text" name="aktionstext" maxlength="200"
+                   value="{{ produkt.aktionstext or '' }}"
+                   placeholder="z.B. Mindesthaltbarkeit 09/2026"
+                   class="w-full bg-stone-800 border border-stone-600 rounded px-3 py-2">
+        </div>
+        <div class="grid grid-cols-2 gap-4">
+            <div>
+                <label class="block text-stone-400 text-sm mb-1">Gültig von <span class="text-stone-500">(optional)</span></label>
+                <input type="date" name="aktion_von" value="{{ produkt.aktion_von or '' }}"
+                       class="w-full bg-stone-800 border border-stone-600 rounded px-3 py-2">
+            </div>
+            <div>
+                <label class="block text-stone-400 text-sm mb-1">Gültig bis <span class="text-stone-500">(optional)</span></label>
+                <input type="date" name="aktion_bis" value="{{ produkt.aktion_bis or '' }}"
+                       class="w-full bg-stone-800 border border-stone-600 rounded px-3 py-2">
+            </div>
+        </div>
+    </div>
+    <button type="submit"
+            class="w-full bg-accent text-stone-900 py-3 rounded font-bold text-lg hover:bg-yellow-400 transition-colors">
+        Speichern
+    </button>
+</form>
+{% endblock %}

--- a/templates/admin/produkte.html
+++ b/templates/admin/produkte.html
@@ -1,0 +1,27 @@
+{% extends "admin/base.html" %}
+{% block title %}Aktionspreise{% endblock %}
+{% block content %}
+<h1 class="font-display text-5xl font-bold text-accent mb-8">Aktionspreise</h1>
+<div class="flex flex-col gap-3">
+    {% for p in produkte %}
+    <div class="bg-stone-700 rounded-lg p-4 shadow-md flex items-center justify-between gap-4">
+        <div>
+            <div class="font-semibold">{{ p.name }}</div>
+            <div class="text-stone-400 text-sm">
+                Normalpreis: CHF {{ "%.2f"|format(p.preis_chf) }}
+                {% if p.aktionspreis_chf %}
+                — <span class="text-accent">Aktion: CHF {{ "%.2f"|format(p.aktionspreis_chf) }}</span>
+                {% if p.aktion_von or p.aktion_bis %}
+                ({{ p.aktion_von or "…" }} – {{ p.aktion_bis or "…" }})
+                {% endif %}
+                {% endif %}
+            </div>
+        </div>
+        <a href="/admin/produkte/{{ p.id }}/aktion"
+           class="bg-accent text-stone-900 px-4 py-2 rounded font-bold hover:bg-yellow-400 transition-colors whitespace-nowrap">
+            {{ "Aktion bearbeiten" if p.aktionspreis_chf else "Aktion setzen" }}
+        </a>
+    </div>
+    {% endfor %}
+</div>
+{% endblock %}

--- a/templates/checkout.html
+++ b/templates/checkout.html
@@ -173,7 +173,11 @@ function rabattcodeEinloesen() {
         return;
     }
 
-    var subtotal = getCartTotal();
+    var subtotal = getRabattSubtotal();
+    if (subtotal <= 0) {
+        zeigeFeedback("Auf Aktionsprodukte ist kein zusätzlicher Rabattcode möglich.", false);
+        return;
+    }
     var btn = document.getElementById("rabattcode-btn");
     btn.disabled = true;
     btn.textContent = "Prüfe...";

--- a/templates/produkte.html
+++ b/templates/produkte.html
@@ -22,20 +22,35 @@
             <h2 class="font-display text-3xl font-bold text-accent drop-shadow-lg mb-6">Unsere Gebinde</h2>
             <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
                 {% for produkt in produkte %}
-                <div class="bg-stone-900/75 backdrop-blur-[4px] rounded-lg p-6 flex flex-col shadow-md border border-stone-600/15 hover:shadow-lg hover:-translate-y-1 transition-all duration-200">
+                <div class="relative bg-stone-900/75 backdrop-blur-[4px] rounded-lg p-6 flex flex-col shadow-md border border-stone-600/15 hover:shadow-lg hover:-translate-y-1 transition-all duration-200">
+                    {% if produkt.ist_aktion %}
+                    <span class="absolute top-3 right-3 bg-red-600 text-white text-xs font-bold px-2 py-1 rounded">RABATT</span>
+                    {% endif %}
                     {% if produkt.bild_pfad %}
                     <img src="/static/images/{{ produkt.bild_pfad }}" alt="{{ produkt.name }}"
                          class="w-full h-48 object-contain mb-4">
                     {% endif %}
                     <h3 class="font-display text-2xl font-bold text-accent">{{ produkt.name }}</h3>
                     <p class="text-stone-200 mt-2 flex-1">{{ produkt.beschreibung }}</p>
+                    {% if produkt.ist_aktion and produkt.aktionstext %}
+                    <p class="text-accent text-sm mt-2">{{ produkt.aktionstext }}</p>
+                    {% endif %}
                     <div class="mt-4 flex items-center justify-between">
-                        <span class="text-xl font-bold">CHF {{ "%.2f"|format(produkt.preis_chf) }}</span>
+                        <div class="flex items-baseline gap-2">
+                            {% if produkt.ist_aktion %}
+                            <span class="text-stone-400 line-through text-sm">CHF {{ "%.2f"|format(produkt.original_preis) }}</span>
+                            <span class="text-xl font-bold">CHF {{ "%.2f"|format(produkt.preis) }}</span>
+                            <span class="bg-accent text-stone-900 text-xs font-bold px-1.5 py-0.5 rounded">−{{ produkt.prozent }}%</span>
+                            {% else %}
+                            <span class="text-xl font-bold">CHF {{ "%.2f"|format(produkt.preis) }}</span>
+                            {% endif %}
+                        </div>
                         <button type="button"
                                 class="add-to-cart-btn bg-accent text-stone-900 px-4 py-2 rounded font-bold hover:bg-yellow-400 transition-colors"
                                 data-product-id="{{ produkt.id }}"
                                 data-product-name="{{ produkt.name }}"
-                                data-product-price="{{ produkt.preis_chf }}"
+                                data-product-price="{{ produkt.preis }}"
+                                data-product-aktion="{{ '1' if produkt.ist_aktion else '0' }}"
                                 data-product-image="/static/images/{{ produkt.bild_pfad }}">
                             In den Warenkorb
                         </button>

--- a/templates/produkte.html
+++ b/templates/produkte.html
@@ -40,7 +40,7 @@
                             {% if produkt.ist_aktion %}
                             <span class="text-stone-400 line-through text-sm">CHF {{ "%.2f"|format(produkt.original_preis) }}</span>
                             <span class="text-xl font-bold">CHF {{ "%.2f"|format(produkt.preis) }}</span>
-                            <span class="bg-accent text-stone-900 text-xs font-bold px-1.5 py-0.5 rounded">−{{ produkt.prozent }}%</span>
+                            {% if produkt.prozent > 0 %}<span class="bg-accent text-stone-900 text-xs font-bold px-1.5 py-0.5 rounded">−{{ produkt.prozent }}%</span>{% endif %}
                             {% else %}
                             <span class="text-xl font-bold">CHF {{ "%.2f"|format(produkt.preis) }}</span>
                             {% endif %}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,6 +54,10 @@ def db(tmp_path):
         "hausnummer",
         "TEXT NOT NULL DEFAULT ''",
     )
+    _add_column_if_not_exists(conn, "produkte", "aktionspreis_chf", "REAL")
+    _add_column_if_not_exists(conn, "produkte", "aktionstext", "TEXT")
+    _add_column_if_not_exists(conn, "produkte", "aktion_von", "TEXT")
+    _add_column_if_not_exists(conn, "produkte", "aktion_bis", "TEXT")
     conn.commit()
     yield conn
     conn.close()

--- a/tests/test_aktions_columns.py
+++ b/tests/test_aktions_columns.py
@@ -1,0 +1,3 @@
+def test_produkte_hat_aktions_spalten(db):
+    cols = {row[1] for row in db.execute("PRAGMA table_info(produkte)")}
+    assert {"aktionspreis_chf", "aktionstext", "aktion_von", "aktion_bis"} <= cols

--- a/tests/test_aktions_service.py
+++ b/tests/test_aktions_service.py
@@ -1,0 +1,54 @@
+from datetime import date
+
+from app.services.aktions_service import effektiver_preis
+
+HEUTE = date(2026, 6, 23)
+
+
+def test_keine_aktion_wenn_aktionspreis_none():
+    ep = effektiver_preis(18.0, None, None, None, HEUTE)
+    assert ep.ist_aktion is False
+    assert ep.preis == 18.0
+    assert ep.original_preis == 18.0
+    assert ep.prozent == 0
+
+
+def test_aktion_ohne_datumsgrenzen_gilt():
+    ep = effektiver_preis(18.0, 12.0, None, None, HEUTE)
+    assert ep.ist_aktion is True
+    assert ep.preis == 12.0
+    assert ep.original_preis == 18.0
+    assert ep.prozent == 33  # round((1-12/18)*100) = 33
+
+
+def test_aktion_vor_beginn_inaktiv():
+    ep = effektiver_preis(18.0, 12.0, "2026-07-01", None, HEUTE)
+    assert ep.ist_aktion is False
+    assert ep.preis == 18.0
+
+
+def test_aktion_nach_ende_inaktiv():
+    ep = effektiver_preis(18.0, 12.0, None, "2026-06-22", HEUTE)
+    assert ep.ist_aktion is False
+    assert ep.preis == 18.0
+
+
+def test_aktion_innerhalb_zeitraum_aktiv():
+    ep = effektiver_preis(18.0, 12.0, "2026-06-01", "2026-06-30", HEUTE)
+    assert ep.ist_aktion is True
+    assert ep.preis == 12.0
+
+
+def test_aktion_grenze_von_inklusive():
+    ep = effektiver_preis(18.0, 12.0, "2026-06-23", "2026-06-30", HEUTE)
+    assert ep.ist_aktion is True
+
+
+def test_aktion_grenze_bis_inklusive():
+    ep = effektiver_preis(18.0, 12.0, "2026-06-01", "2026-06-23", HEUTE)
+    assert ep.ist_aktion is True
+
+
+def test_leere_strings_wie_none_behandelt():
+    ep = effektiver_preis(18.0, 12.0, "", "", HEUTE)
+    assert ep.ist_aktion is True

--- a/tests/test_aktionspreis_bestellung.py
+++ b/tests/test_aktionspreis_bestellung.py
@@ -36,10 +36,17 @@ def test_code_nur_auf_nicht_aktions_anteil(client, csrf_token):
     resp = client.post(
         "/bestellen",
         data={
-            "vorname": "T", "nachname": "U", "email": "t@example.com",
-            "strasse": "Str. 1", "plz": "4600", "ort": "Olten",
-            "versandart": "abholung", "zahlungsart": "abholung_bar",
-            "cart_data": cart, "rabattcode": "ZEHN", "csrf_token": csrf_token,
+            "vorname": "T",
+            "nachname": "U",
+            "email": "t@example.com",
+            "strasse": "Str. 1",
+            "plz": "4600",
+            "ort": "Olten",
+            "versandart": "abholung",
+            "zahlungsart": "abholung_bar",
+            "cart_data": cart,
+            "rabattcode": "ZEHN",
+            "csrf_token": csrf_token,
         },
         follow_redirects=False,
     )
@@ -62,10 +69,17 @@ def test_reiner_aktionswarenkorb_lehnt_code_ab(client, csrf_token):
     resp = client.post(
         "/bestellen",
         data={
-            "vorname": "T", "nachname": "U", "email": "t@example.com",
-            "strasse": "Str. 1", "plz": "4600", "ort": "Olten",
-            "versandart": "abholung", "zahlungsart": "abholung_bar",
-            "cart_data": cart, "rabattcode": "ZEHN", "csrf_token": csrf_token,
+            "vorname": "T",
+            "nachname": "U",
+            "email": "t@example.com",
+            "strasse": "Str. 1",
+            "plz": "4600",
+            "ort": "Olten",
+            "versandart": "abholung",
+            "zahlungsart": "abholung_bar",
+            "cart_data": cart,
+            "rabattcode": "ZEHN",
+            "csrf_token": csrf_token,
         },
         follow_redirects=False,
     )

--- a/tests/test_aktionspreis_bestellung.py
+++ b/tests/test_aktionspreis_bestellung.py
@@ -1,0 +1,72 @@
+import json
+
+
+def _setze_aktion(produkt_id, aktionspreis):
+    from app.database import get_db
+
+    conn = get_db()
+    conn.execute(
+        "UPDATE produkte SET aktionspreis_chf = ? WHERE id = ?",
+        (aktionspreis, produkt_id),
+    )
+    conn.commit()
+    conn.close()
+
+
+def _erstelle_rabattcode(code, art, wert):
+    from app.database import get_db
+
+    conn = get_db()
+    conn.execute(
+        "INSERT INTO rabattcodes (code, rabattart, rabattwert, gueltig_von, "
+        "gueltig_bis) VALUES (?, ?, ?, '2026-01-01', '2026-12-31')",
+        (code, art, wert),
+    )
+    conn.commit()
+    conn.close()
+
+
+def test_code_nur_auf_nicht_aktions_anteil(client, csrf_token):
+    from app.database import get_db
+
+    _setze_aktion(2, 12.0)  # Produkt 2 in Aktion
+    _erstelle_rabattcode("ZEHN", "prozent", 10.0)
+    # Warenkorb: 1x Produkt 1 (8.- normal) + 1x Produkt 2 (12.- Aktion)
+    cart = json.dumps([{"produkt_id": 1, "menge": 1}, {"produkt_id": 2, "menge": 1}])
+    resp = client.post(
+        "/bestellen",
+        data={
+            "vorname": "T", "nachname": "U", "email": "t@example.com",
+            "strasse": "Str. 1", "plz": "4600", "ort": "Olten",
+            "versandart": "abholung", "zahlungsart": "abholung_bar",
+            "cart_data": cart, "rabattcode": "ZEHN", "csrf_token": csrf_token,
+        },
+        follow_redirects=False,
+    )
+    assert resp.status_code in (200, 303)
+    conn = get_db()
+    row = conn.execute(
+        "SELECT rabattbetrag_chf, total_chf FROM bestellungen WHERE id = 1"
+    ).fetchone()
+    conn.close()
+    # 10% nur auf den 8.- Nicht-Aktionsanteil = 0.80 (5-Rappen-gerundet)
+    assert row["rabattbetrag_chf"] == 0.80
+    # Total: 8 + 12 - 0.80 + 0 Versand = 19.20
+    assert row["total_chf"] == 19.20
+
+
+def test_reiner_aktionswarenkorb_lehnt_code_ab(client, csrf_token):
+    _setze_aktion(2, 12.0)
+    _erstelle_rabattcode("ZEHN", "prozent", 10.0)
+    cart = json.dumps([{"produkt_id": 2, "menge": 1}])  # nur Aktionsware
+    resp = client.post(
+        "/bestellen",
+        data={
+            "vorname": "T", "nachname": "U", "email": "t@example.com",
+            "strasse": "Str. 1", "plz": "4600", "ort": "Olten",
+            "versandart": "abholung", "zahlungsart": "abholung_bar",
+            "cart_data": cart, "rabattcode": "ZEHN", "csrf_token": csrf_token,
+        },
+        follow_redirects=False,
+    )
+    assert resp.status_code == 400

--- a/tests/test_api_produkt_admin.py
+++ b/tests/test_api_produkt_admin.py
@@ -56,8 +56,11 @@ def test_admin_aktion_setzen(tmp_path, monkeypatch):
     resp = admin_client.post(
         "/admin/produkte/2/aktion",
         data={
-            "aktionspreis_chf": "12.00", "aktionstext": "MHD 09/2026",
-            "aktion_von": "", "aktion_bis": "", "csrf_token": csrf,
+            "aktionspreis_chf": "12.00",
+            "aktionstext": "MHD 09/2026",
+            "aktion_von": "",
+            "aktion_bis": "",
+            "csrf_token": csrf,
         },
         follow_redirects=False,
     )
@@ -81,8 +84,11 @@ def test_admin_aktion_groesser_als_preis_abgelehnt(tmp_path, monkeypatch):
     resp = admin_client.post(
         "/admin/produkte/2/aktion",
         data={
-            "aktionspreis_chf": "20.00", "aktionstext": "zu teuer",
-            "aktion_von": "", "aktion_bis": "", "csrf_token": csrf,
+            "aktionspreis_chf": "20.00",
+            "aktionstext": "zu teuer",
+            "aktion_von": "",
+            "aktion_bis": "",
+            "csrf_token": csrf,
         },
         follow_redirects=False,
     )
@@ -103,15 +109,25 @@ def test_admin_aktion_entfernen(tmp_path, monkeypatch):
     # erst setzen
     admin_client.post(
         "/admin/produkte/2/aktion",
-        data={"aktionspreis_chf": "12.00", "aktionstext": "x",
-              "aktion_von": "", "aktion_bis": "", "csrf_token": csrf},
+        data={
+            "aktionspreis_chf": "12.00",
+            "aktionstext": "x",
+            "aktion_von": "",
+            "aktion_bis": "",
+            "csrf_token": csrf,
+        },
         follow_redirects=False,
     )
     # dann leerer Aktionspreis = entfernen
     resp = admin_client.post(
         "/admin/produkte/2/aktion",
-        data={"aktionspreis_chf": "", "aktionstext": "",
-              "aktion_von": "", "aktion_bis": "", "csrf_token": csrf},
+        data={
+            "aktionspreis_chf": "",
+            "aktionstext": "",
+            "aktion_von": "",
+            "aktion_bis": "",
+            "csrf_token": csrf,
+        },
         follow_redirects=False,
     )
     assert resp.status_code == 303
@@ -137,8 +153,11 @@ def test_admin_aktion_ungueltige_eingabe(tmp_path, monkeypatch):
     resp = admin_client.post(
         "/admin/produkte/2/aktion",
         data={
-            "aktionspreis_chf": "abc", "aktionstext": "invalid",
-            "aktion_von": "", "aktion_bis": "", "csrf_token": csrf,
+            "aktionspreis_chf": "abc",
+            "aktionstext": "invalid",
+            "aktion_von": "",
+            "aktion_bis": "",
+            "csrf_token": csrf,
         },
         follow_redirects=False,
     )

--- a/tests/test_api_produkt_admin.py
+++ b/tests/test_api_produkt_admin.py
@@ -1,0 +1,129 @@
+def _make_admin_client(tmp_path, monkeypatch):
+    import bcrypt
+    from fastapi.testclient import TestClient
+
+    pw_hash = bcrypt.hashpw(b"testpass", bcrypt.gensalt()).decode()
+    monkeypatch.setattr(
+        "app.config.settings.database_path", str(tmp_path / "admin_test.db")
+    )
+    monkeypatch.setattr("app.config.settings.admin_credentials", f"dev:{pw_hash}")
+    monkeypatch.setattr("app.config.settings.cookie_secure", False)
+    from app.database import init_db
+
+    init_db()
+    from app.main import app
+
+    return TestClient(app)
+
+
+def _admin_login(admin_client):
+    from app.config import settings
+    from app.csrf import generiere_csrf_token
+
+    get_resp = admin_client.get("/admin/login")
+    csrf_id = get_resp.cookies.get("csrf_id", "")
+    csrf = generiere_csrf_token(settings.secret_key, identity=f"anon:{csrf_id}")
+    resp = admin_client.post(
+        "/admin/login",
+        data={"password": "testpass", "csrf_token": csrf},
+        follow_redirects=False,
+    )
+    return resp.cookies
+
+
+def _csrf_fuer_session(cookies):
+    from app.config import settings
+    from app.csrf import admin_identity, generiere_csrf_token
+
+    return generiere_csrf_token(
+        settings.secret_key, identity=admin_identity(cookies.get("admin_session"))
+    )
+
+
+def test_admin_produkte_liste(tmp_path, monkeypatch):
+    admin_client = _make_admin_client(tmp_path, monkeypatch)
+    admin_client.cookies = _admin_login(admin_client)
+    resp = admin_client.get("/admin/produkte")
+    assert resp.status_code == 200
+    assert "Olivenöl 750ml" in resp.text
+
+
+def test_admin_aktion_setzen(tmp_path, monkeypatch):
+    admin_client = _make_admin_client(tmp_path, monkeypatch)
+    cookies = _admin_login(admin_client)
+    admin_client.cookies = cookies
+    csrf = _csrf_fuer_session(cookies)
+    resp = admin_client.post(
+        "/admin/produkte/2/aktion",
+        data={
+            "aktionspreis_chf": "12.00", "aktionstext": "MHD 09/2026",
+            "aktion_von": "", "aktion_bis": "", "csrf_token": csrf,
+        },
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+    from app.database import get_db
+
+    conn = get_db()
+    row = conn.execute(
+        "SELECT aktionspreis_chf, aktionstext FROM produkte WHERE id = 2"
+    ).fetchone()
+    conn.close()
+    assert row["aktionspreis_chf"] == 12.0
+    assert row["aktionstext"] == "MHD 09/2026"
+
+
+def test_admin_aktion_groesser_als_preis_abgelehnt(tmp_path, monkeypatch):
+    admin_client = _make_admin_client(tmp_path, monkeypatch)
+    cookies = _admin_login(admin_client)
+    admin_client.cookies = cookies
+    csrf = _csrf_fuer_session(cookies)
+    resp = admin_client.post(
+        "/admin/produkte/2/aktion",
+        data={
+            "aktionspreis_chf": "20.00", "aktionstext": "zu teuer",
+            "aktion_von": "", "aktion_bis": "", "csrf_token": csrf,
+        },
+        follow_redirects=False,
+    )
+    assert resp.status_code == 400
+    from app.database import get_db
+
+    conn = get_db()
+    row = conn.execute("SELECT aktionspreis_chf FROM produkte WHERE id = 2").fetchone()
+    conn.close()
+    assert row["aktionspreis_chf"] is None
+
+
+def test_admin_aktion_entfernen(tmp_path, monkeypatch):
+    admin_client = _make_admin_client(tmp_path, monkeypatch)
+    cookies = _admin_login(admin_client)
+    admin_client.cookies = cookies
+    csrf = _csrf_fuer_session(cookies)
+    # erst setzen
+    admin_client.post(
+        "/admin/produkte/2/aktion",
+        data={"aktionspreis_chf": "12.00", "aktionstext": "x",
+              "aktion_von": "", "aktion_bis": "", "csrf_token": csrf},
+        follow_redirects=False,
+    )
+    # dann leerer Aktionspreis = entfernen
+    resp = admin_client.post(
+        "/admin/produkte/2/aktion",
+        data={"aktionspreis_chf": "", "aktionstext": "",
+              "aktion_von": "", "aktion_bis": "", "csrf_token": csrf},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+    from app.database import get_db
+
+    conn = get_db()
+    row = conn.execute("SELECT aktionspreis_chf FROM produkte WHERE id = 2").fetchone()
+    conn.close()
+    assert row["aktionspreis_chf"] is None
+
+
+def test_admin_produkte_ohne_login_redirect(tmp_path, monkeypatch):
+    admin_client = _make_admin_client(tmp_path, monkeypatch)
+    resp = admin_client.get("/admin/produkte", follow_redirects=False)
+    assert resp.status_code == 303

--- a/tests/test_api_produkt_admin.py
+++ b/tests/test_api_produkt_admin.py
@@ -143,3 +143,49 @@ def test_admin_aktion_ungueltige_eingabe(tmp_path, monkeypatch):
         follow_redirects=False,
     )
     assert resp.status_code == 400
+
+
+def test_admin_aktion_datum_invertiert_abgelehnt(tmp_path, monkeypatch):
+    """F2: aktion_von > aktion_bis muss HTTP 400 liefern; DB bleibt unverändert."""
+    admin_client = _make_admin_client(tmp_path, monkeypatch)
+    cookies = _admin_login(admin_client)
+    admin_client.cookies = cookies
+    csrf = _csrf_fuer_session(cookies)
+    resp = admin_client.post(
+        "/admin/produkte/2/aktion",
+        data={
+            "aktionspreis_chf": "12.00",
+            "aktionstext": "Test",
+            "aktion_von": "2026-12-31",
+            "aktion_bis": "2026-01-01",
+            "csrf_token": csrf,
+        },
+        follow_redirects=False,
+    )
+    assert resp.status_code == 400
+    from app.database import get_db
+
+    conn = get_db()
+    row = conn.execute("SELECT aktionspreis_chf FROM produkte WHERE id = 2").fetchone()
+    conn.close()
+    assert row["aktionspreis_chf"] is None
+
+
+def test_admin_aktion_ungueliges_datum_format_abgelehnt(tmp_path, monkeypatch):
+    """F3: Ungültiges ISO-Datum in aktion_von muss HTTP 400 liefern."""
+    admin_client = _make_admin_client(tmp_path, monkeypatch)
+    cookies = _admin_login(admin_client)
+    admin_client.cookies = cookies
+    csrf = _csrf_fuer_session(cookies)
+    resp = admin_client.post(
+        "/admin/produkte/2/aktion",
+        data={
+            "aktionspreis_chf": "12.00",
+            "aktionstext": "Test",
+            "aktion_von": "notadate",
+            "aktion_bis": "",
+            "csrf_token": csrf,
+        },
+        follow_redirects=False,
+    )
+    assert resp.status_code == 400

--- a/tests/test_api_produkt_admin.py
+++ b/tests/test_api_produkt_admin.py
@@ -127,3 +127,19 @@ def test_admin_produkte_ohne_login_redirect(tmp_path, monkeypatch):
     admin_client = _make_admin_client(tmp_path, monkeypatch)
     resp = admin_client.get("/admin/produkte", follow_redirects=False)
     assert resp.status_code == 303
+
+
+def test_admin_aktion_ungueltige_eingabe(tmp_path, monkeypatch):
+    admin_client = _make_admin_client(tmp_path, monkeypatch)
+    cookies = _admin_login(admin_client)
+    admin_client.cookies = cookies
+    csrf = _csrf_fuer_session(cookies)
+    resp = admin_client.post(
+        "/admin/produkte/2/aktion",
+        data={
+            "aktionspreis_chf": "abc", "aktionstext": "invalid",
+            "aktion_von": "", "aktion_bis": "", "csrf_token": csrf,
+        },
+        follow_redirects=False,
+    )
+    assert resp.status_code == 400

--- a/tests/test_api_produkte.py
+++ b/tests/test_api_produkte.py
@@ -124,3 +124,26 @@ def test_startseite_hintergrund_olivenbaum(client):
     assert "backgrounds/olive-tree-hero.jpg" in response.text
     # Vorheriger Terracotta-Hintergrund ist ersetzt
     assert "backgrounds/terracotta-texture.webp" not in response.text
+
+
+def test_startseite_zeigt_aktionspreis(client):
+    from app.database import get_db
+
+    conn = get_db()
+    conn.execute(
+        "UPDATE produkte SET aktionspreis_chf = 12.0, "
+        "aktionstext = 'MHD 09/2026' WHERE id = 2"
+    )
+    conn.commit()
+    conn.close()
+    resp = client.get("/")
+    assert resp.status_code == 200
+    assert "RABATT" in resp.text
+    assert "MHD 09/2026" in resp.text
+    assert "CHF 12.00" in resp.text
+
+
+def test_startseite_ohne_aktion_kein_badge(client):
+    resp = client.get("/")
+    assert resp.status_code == 200
+    assert "RABATT" not in resp.text

--- a/tests/test_api_produkte.py
+++ b/tests/test_api_produkte.py
@@ -147,3 +147,26 @@ def test_startseite_ohne_aktion_kein_badge(client):
     resp = client.get("/")
     assert resp.status_code == 200
     assert "RABATT" not in resp.text
+
+
+def test_startseite_aktion_null_prozent_badge_versteckt(client):
+    """F4: Aktionspreis der auf 0% rundet zeigt kein '−0%'-Badge.
+
+    750ml kostet CHF 18.00. Aktionspreis CHF 17.95 → Rabatt 0.28% → rundet
+    zu 0 (round(0.28) == 0). Das RABATT-Badge und der durchgestrichene Preis
+    bleiben erhalten, aber der Prozent-Chip '−0%' darf nicht sichtbar sein.
+    """
+    from app.database import get_db
+
+    conn = get_db()
+    conn.execute(
+        "UPDATE produkte SET aktionspreis_chf = 17.95 WHERE id = 2"
+    )
+    conn.commit()
+    conn.close()
+    resp = client.get("/")
+    assert resp.status_code == 200
+    # RABATT-Badge bleibt sichtbar
+    assert "RABATT" in resp.text
+    # Prozent-Chip mit −0% darf nicht erscheinen (U+2212 Minus)
+    assert "−0" not in resp.text

--- a/tests/test_api_produkte.py
+++ b/tests/test_api_produkte.py
@@ -159,9 +159,7 @@ def test_startseite_aktion_null_prozent_badge_versteckt(client):
     from app.database import get_db
 
     conn = get_db()
-    conn.execute(
-        "UPDATE produkte SET aktionspreis_chf = 17.95 WHERE id = 2"
-    )
+    conn.execute("UPDATE produkte SET aktionspreis_chf = 17.95 WHERE id = 2")
     conn.commit()
     conn.close()
     resp = client.get("/")

--- a/tests/test_bestell_service.py
+++ b/tests/test_bestell_service.py
@@ -1,7 +1,13 @@
+from datetime import date
+
 import pytest
 
 from app.models import WarenkorbItem
-from app.services.bestell_service import berechne_total, berechne_versandkosten
+from app.services.bestell_service import (
+    berechne_total,
+    berechne_versandkosten,
+    rabattfaehiger_subtotal,
+)
 
 
 def test_versandkosten_unter_100():
@@ -30,3 +36,42 @@ def test_berechne_total_ungueltige_produkt_id(db):
     items = [WarenkorbItem(produkt_id=999, menge=1)]
     with pytest.raises(ValueError, match="Produkt 999 nicht gefunden"):
         berechne_total(db, items)
+
+
+def test_berechne_total_mit_aktionspreis(db):
+    db.execute(
+        "UPDATE produkte SET aktionspreis_chf = 12.0, aktion_von = '2026-06-01', "
+        "aktion_bis = '2026-06-30' WHERE id = 2"
+    )
+    db.commit()
+    items = [WarenkorbItem(produkt_id=2, menge=1)]  # statt 18 jetzt 12
+    total, positionen = berechne_total(db, items, heute=date(2026, 6, 23))
+    assert total == 12.0
+    assert positionen[0]["einzelpreis_chf"] == 12.0
+    assert positionen[0]["ist_aktion"] is True
+    assert positionen[0]["original_preis_chf"] == 18.0
+
+
+def test_berechne_total_aktion_abgelaufen_normalpreis(db):
+    db.execute(
+        "UPDATE produkte SET aktionspreis_chf = 12.0, aktion_bis = '2026-06-22' "
+        "WHERE id = 2"
+    )
+    db.commit()
+    items = [WarenkorbItem(produkt_id=2, menge=1)]
+    total, positionen = berechne_total(db, items, heute=date(2026, 6, 23))
+    assert total == 18.0
+    assert positionen[0]["ist_aktion"] is False
+
+
+def test_rabattfaehiger_subtotal_nur_nicht_aktion():
+    positionen = [
+        {"einzelpreis_chf": 8.0, "menge": 2, "ist_aktion": False},  # 16
+        {"einzelpreis_chf": 12.0, "menge": 1, "ist_aktion": True},  # ausgeschlossen
+    ]
+    assert rabattfaehiger_subtotal(positionen) == 16.0
+
+
+def test_rabattfaehiger_subtotal_reine_aktion_null():
+    positionen = [{"einzelpreis_chf": 12.0, "menge": 1, "ist_aktion": True}]
+    assert rabattfaehiger_subtotal(positionen) == 0.0

--- a/tests/test_produkt_repo.py
+++ b/tests/test_produkt_repo.py
@@ -36,3 +36,42 @@ def test_get_alle_produkte_ohne_aktion_felder_none(db):
     produkte = get_alle_produkte(db)
     p1 = next(p for p in produkte if p.id == 1)
     assert p1.aktionspreis_chf is None
+
+
+def test_aktion_setzen_und_laden(db):
+    from app.repositories.produkt_repo import aktion_setzen, produkt_laden
+
+    aktion_setzen(
+        db, 2, aktionspreis_chf=12.0, aktionstext="MHD 09/2026",
+        aktion_von="2026-06-01", aktion_bis="2026-06-30",
+    )
+    p = produkt_laden(db, 2)
+    assert p["aktionspreis_chf"] == 12.0
+    assert p["aktionstext"] == "MHD 09/2026"
+    assert p["aktion_von"] == "2026-06-01"
+    assert p["aktion_bis"] == "2026-06-30"
+
+
+def test_aktion_entfernen_setzt_null(db):
+    from app.repositories.produkt_repo import (
+        aktion_entfernen,
+        aktion_setzen,
+        produkt_laden,
+    )
+
+    aktion_setzen(db, 2, aktionspreis_chf=12.0, aktionstext="x",
+                  aktion_von=None, aktion_bis=None)
+    aktion_entfernen(db, 2)
+    p = produkt_laden(db, 2)
+    assert p["aktionspreis_chf"] is None
+    assert p["aktionstext"] is None
+    assert p["aktion_von"] is None
+    assert p["aktion_bis"] is None
+
+
+def test_alle_produkte_admin_enthaelt_alle(db):
+    from app.repositories.produkt_repo import alle_produkte_admin
+
+    produkte = alle_produkte_admin(db)
+    assert len(produkte) == 3
+    assert produkte[0]["menge_ml"] <= produkte[-1]["menge_ml"]

--- a/tests/test_produkt_repo.py
+++ b/tests/test_produkt_repo.py
@@ -12,3 +12,27 @@ def test_get_alle_produkte_nur_aktive(db):
     db.commit()
     produkte = get_alle_produkte(db)
     assert len(produkte) == 2
+
+
+def test_get_alle_produkte_liefert_aktions_felder(db):
+    from app.repositories.produkt_repo import get_alle_produkte
+
+    db.execute(
+        "UPDATE produkte SET aktionspreis_chf = 12.0, aktionstext = 'MHD 09/2026', "
+        "aktion_von = '2026-06-01', aktion_bis = '2026-06-30' WHERE id = 2"
+    )
+    db.commit()
+    produkte = get_alle_produkte(db)
+    p2 = next(p for p in produkte if p.id == 2)
+    assert p2.aktionspreis_chf == 12.0
+    assert p2.aktionstext == "MHD 09/2026"
+    assert p2.aktion_von == "2026-06-01"
+    assert p2.aktion_bis == "2026-06-30"
+
+
+def test_get_alle_produkte_ohne_aktion_felder_none(db):
+    from app.repositories.produkt_repo import get_alle_produkte
+
+    produkte = get_alle_produkte(db)
+    p1 = next(p for p in produkte if p.id == 1)
+    assert p1.aktionspreis_chf is None

--- a/tests/test_produkt_repo.py
+++ b/tests/test_produkt_repo.py
@@ -42,8 +42,12 @@ def test_aktion_setzen_und_laden(db):
     from app.repositories.produkt_repo import aktion_setzen, produkt_laden
 
     aktion_setzen(
-        db, 2, aktionspreis_chf=12.0, aktionstext="MHD 09/2026",
-        aktion_von="2026-06-01", aktion_bis="2026-06-30",
+        db,
+        2,
+        aktionspreis_chf=12.0,
+        aktionstext="MHD 09/2026",
+        aktion_von="2026-06-01",
+        aktion_bis="2026-06-30",
     )
     p = produkt_laden(db, 2)
     assert p["aktionspreis_chf"] == 12.0
@@ -59,8 +63,9 @@ def test_aktion_entfernen_setzt_null(db):
         produkt_laden,
     )
 
-    aktion_setzen(db, 2, aktionspreis_chf=12.0, aktionstext="x",
-                  aktion_von=None, aktion_bis=None)
+    aktion_setzen(
+        db, 2, aktionspreis_chf=12.0, aktionstext="x", aktion_von=None, aktion_bis=None
+    )
     aktion_entfernen(db, 2)
     p = produkt_laden(db, 2)
     assert p["aktionspreis_chf"] is None

--- a/tests/test_seed_aktion_persistenz.py
+++ b/tests/test_seed_aktion_persistenz.py
@@ -1,0 +1,73 @@
+"""Regressionsschutz: Der Produkt-Seed darf admin-gesetzte Aktionen nicht
+bei jedem Neustart überschreiben (Bug #137, Fix zu #134).
+
+init_db() läuft bei jedem Container-Start und führt den Seed erneut aus.
+Mit INSERT OR REPLACE fielen die admin-editierbaren Aktions-Spalten dabei
+auf NULL zurück — eine im Admin gesetzte Aktion verschwand stillschweigend
+bei jedem Deploy/Maschinenneustart. Der Seed nutzt deshalb ein UPSERT, das
+nur die Katalog-Spalten aktualisiert.
+"""
+
+import sqlite3
+
+from app.database import init_db
+from app.repositories.produkt_repo import aktion_setzen, produkt_laden
+
+
+def test_seed_ueberschreibt_admin_aktion_nicht(monkeypatch, tmp_path):
+    db_path = str(tmp_path / "olivalle-test.db")
+    monkeypatch.setattr("app.config.settings.database_path", db_path)
+
+    # Erster Boot: DB anlegen und seeden.
+    init_db()
+
+    # Inhaber setzt im Admin eine Aktion auf das 250ml-Produkt.
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    aktion_setzen(
+        conn,
+        1,
+        aktionspreis_chf=6.0,
+        aktionstext="Sommeraktion",
+        aktion_von=None,
+        aktion_bis=None,
+    )
+    conn.close()
+
+    # Zweiter Boot (z. B. Deploy, fly.io-Neustart, Litestream-Restore).
+    init_db()
+
+    # Aktion muss den Neustart überleben.
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    produkt = produkt_laden(conn, 1)
+    conn.close()
+
+    assert produkt is not None
+    assert produkt["aktionspreis_chf"] == 6.0
+    assert produkt["aktionstext"] == "Sommeraktion"
+
+
+def test_seed_aktualisiert_katalog_spalten_weiterhin(monkeypatch, tmp_path):
+    """Gegenprobe: Katalog-Korrekturen per Migration greifen weiterhin bei
+    jedem Boot (sonst wäre INSERT OR IGNORE gewählt worden)."""
+    db_path = str(tmp_path / "olivalle-test.db")
+    monkeypatch.setattr("app.config.settings.database_path", db_path)
+
+    init_db()
+
+    # Katalog-Spalte von Hand verfälschen, dann Neustart simulieren.
+    conn = sqlite3.connect(db_path)
+    conn.execute("UPDATE produkte SET preis_chf = 999 WHERE id = 1")
+    conn.commit()
+    conn.close()
+
+    init_db()
+
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    produkt = produkt_laden(conn, 1)
+    conn.close()
+
+    # Seed stellt den Katalog-Preis wieder her.
+    assert produkt["preis_chf"] == 8.0

--- a/uv.lock
+++ b/uv.lock
@@ -768,7 +768,7 @@ s3 = [
 
 [[package]]
 name = "olivalle"
-version = "1.2"
+version = "1.3"
 source = { virtual = "." }
 dependencies = [
     { name = "bcrypt" },


### PR DESCRIPTION
## Überblick

Schliesst **#134** (produktbezogene, befristete Aktionspreise mit Begründungstext) ab und behebt den dabei im Brainstorming zu #135 entdeckten **#137** (Seed überschrieb admin-gesetzte Aktionen bei jedem Neustart).

## #134 — Aktionspreise
- 4 optionale Spalten auf `produkte` (`aktionspreis_chf`, `aktionstext`, `aktion_von`, `aktion_bis`)
- Zentrale Preisfunktion `aktions_service.effektiver_preis()` — einzige Stelle der Preislogik
- Produktkarte mit RABATT-Badge, durchgestrichenem Originalpreis, –%-Badge, Begründungstext
- Admin Self-Service unter `/admin/produkte` (CSRF, Audit-Log), HTTP-400 bei ungültiger Eingabe
- Rabattcode greift nur auf `rabattfaehiger_subtotal` (Nicht-Aktionsanteil)

## #137 — Seed-Persistenz-Fix (Wurzel)
`init_db()` läuft bei jedem Container-Boot. Der Seed nutzte `INSERT OR REPLACE` → ersetzte die ganze Produktzeile → admin-gesetzte Aktionen fielen auf NULL zurück (bei jedem Deploy/fly.io-Neustart/Litestream-Restore). Umstellung auf `INSERT … ON CONFLICT(id) DO UPDATE SET <nur Katalog-Spalten>`; Aktions-Spalten bleiben unberührt. Regressionstest `tests/test_seed_aktion_persistenz.py` (zwei init_db-Läufe). War nie in Produktion — Fix vor dem Merge eingearbeitet.

## Qualität
- **251 Tests grün** (inkl. 2 neue Regressionstests)
- Ruff Check + Format sauber (Format-Normalisierung auf gepinnte 0.15.7, sonst CI-Fail)
- Code-Review der Fix-Commits: keine Critical/Important-Befunde
- Doku aktualisiert: arc42, user-stories-testplan, Design-Specs

Fixes #134
Fixes #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)