### PR TITLE
fix: Rabattcode-Einlösen — Cache-Busting + Handler-Doppelbindung

### DIFF
--- a/docs/user-stories-testplan.md
+++ b/docs/user-stories-testplan.md
@@ -267,6 +267,8 @@
 | [ ] 13 | 5-Rappen-Rundung prüfen (z.B. 10% auf CHF 18 = CHF 1.80 → Total CHF 16.20) | Total auf 5 Rappen gerundet (CHF 16.20) |
 | [ ] 14 | Zweiten Code "FEST5" bei einer Bestellung versuchen (nach "SOMMER10") | Fehlermeldung "Pro Bestellung nur ein Code erlaubt" |
 | [ ] 15 | Admin: Code "SOMMER10" in der Übersicht prüfen | Anzahl Einlösungen wurde erhöht |
+| [ ] 16 | Checkout: Eingelösten Code über "Entfernen" wieder entfernen | Rabatt verschwindet, Total zurück auf Originalpreis, Eingabefeld wieder editierbar, Button zeigt "Einlösen" |
+| [ ] 17 | Checkout: Nach dem Entfernen denselben Code erneut eingeben und einlösen | Rabatt wird erneut korrekt angewendet (kein hängender/gesperrter Zustand) |
 
 ---
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{% block title %}Olivalle{% endblock %} — Biologisches Olivenöl</title>
-    <link rel="stylesheet" href="{{ url_for('static', path='css/app.css') }}">
+    <link rel="stylesheet" href="{{ url_for('static', path='css/app.css') }}?v={{ app_version }}">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Amatic+SC:wght@400;700&family=Lora:ital,wght@0,400;0,600;1,400&display=swap" rel="stylesheet">
@@ -18,7 +18,7 @@
     {# cart.js muss im <head> stehen, damit getCart/getCartTotal etc. beim Parsen
        inline <script>-Bloecke im Body (checkout.html, warenkorb.html) bereits
        verfuegbar sind. DOMContentLoaded-Listener in cart.js feuern wie gehabt. #}
-    <script src="/static/js/cart.js"></script>
+    <script src="/static/js/cart.js?v={{ app_version }}"></script>
 </head>
 <body class="bg-stone-800 text-white min-h-screen flex flex-col font-body">
     <header class="sticky top-0 z-50 bg-stone-800/90 backdrop-blur-sm border-b border-stone-700 py-4">

--- a/templates/checkout.html
+++ b/templates/checkout.html
@@ -159,7 +159,15 @@ document.querySelectorAll('input[name="versandart"]').forEach(function(radio) {
 // Rabattcode-Logik
 var aktuellerRabatt = null;
 
-document.getElementById("rabattcode-btn").addEventListener("click", rabattcodeEinloesen);
+// Ein einziger Handler, der je nach Zustand ein- oder auslöst. Kein Mix aus
+// addEventListener + onclick — sonst feuern beide Aktionen gleichzeitig.
+document.getElementById("rabattcode-btn").addEventListener("click", function() {
+    if (aktuellerRabatt) {
+        rabattcodeEntfernen();
+    } else {
+        rabattcodeEinloesen();
+    }
+});
 
 function rabattcodeEinloesen() {
     var codeInput = document.getElementById("rabattcode-input");
@@ -194,7 +202,6 @@ function rabattcodeEinloesen() {
             document.getElementById("rabattcode-hidden").value = data.code;
             zeigeFeedback(data.code + " — " + data.beschreibung, true);
             btn.textContent = "Entfernen";
-            btn.onclick = rabattcodeEntfernen;
             codeInput.disabled = true;
         } else {
             zeigeFeedback(data.fehler, false);
@@ -218,7 +225,6 @@ function rabattcodeEntfernen() {
     document.getElementById("rabattcode-feedback").classList.add("hidden");
     var btn = document.getElementById("rabattcode-btn");
     btn.textContent = "Einlösen";
-    btn.onclick = rabattcodeEinloesen;
     aktualisierePreiszusammenfassung();
 }
 

--- a/tests/test_static_cache_busting.py
+++ b/tests/test_static_cache_busting.py
@@ -1,0 +1,22 @@
+"""Statische Assets (JS/CSS) müssen pro Deploy cache-bustend referenziert werden.
+
+Hintergrund: Ohne Versions-Query darf der Browser eine veraltete `cart.js`
+ausliefern. Fehlt darin eine Funktion (z.B. getRabattSubtotal, eingeführt mit
+#134), bricht der Rabattcode-Handler im Checkout lautlos ab — der Button "tut
+nichts". Ein `?v={app_version}` an JS/CSS erzwingt nach jedem Deploy einen
+Neuladen.
+"""
+
+from app.config import settings
+
+
+def test_cart_js_ist_cache_bustend_referenziert(client):
+    """base.html muss cart.js mit ?v=<app_version> einbinden."""
+    html = client.get("/").text
+    assert f"/static/js/cart.js?v={settings.app_version}" in html
+
+
+def test_app_css_ist_cache_bustend_referenziert(client):
+    """base.html muss app.css mit ?v=<app_version> einbinden."""
+    html = client.get("/").text
+    assert f"css/app.css?v={settings.app_version}" in html


### PR DESCRIPTION
## Problem

Bei einem Testkauf tat der **"Einlösen"**-Button beim Rabattcode nichts — keine Rückmeldung, keine Änderung der Seite. Systematisches Debugging (inkl. Reproduktion im Headless-Browser gegen Live) deckte **zwei** Ursachen auf.

## Issue A — erklärt das gemeldete Symptom: veralteter JS-Cache

`cart.js` und `app.css` wurden **ohne Cache-Busting** referenziert und von FastAPI StaticFiles **ohne `Cache-Control`** ausgeliefert → Browser dürfen heuristisch eine alte Kopie weiterverwenden.

`getRabattSubtotal()` kam erst mit dem #134-Deploy dazu. Wer vorher die Seite besucht hatte, bekam u.U. die **alte `cart.js`** aus dem Cache → die Funktion fehlt → der Klick-Handler wirft `getRabattSubtotal is not a function` und bricht **lautlos** ab. Pro Browser/Cache-Zustand unterschiedlich — deshalb mal reproduzierbar, mal nicht.

**Reproduziert** (simulierte alte cart.js): Klick → Feedback bleibt versteckt, Button bleibt "Einlösen", nur Konsolenfehler. Exakt das gemeldete Verhalten.

**Fix:** `?v={{ app_version }}` an JS/CSS in `base.html`. Der CI-Deploy berechnet pro Deploy eine echte, distincte `app_version` (`v{MINOR}.{PATCH}`) → Browser lädt garantiert neu.

## Issue B — separater Bug (beim Debuggen gefunden): Handler-Doppelbindung

In `checkout.html` wurde `addEventListener("click", rabattcodeEinloesen)` (nie entfernt) mit `btn.onclick = rabattcodeEntfernen` vermischt. Im "Entfernen"-Zustand feuerten **beide** Aktionen; der asynchrone Re-Fetch überschrieb das Aufräumen → Rabatt blieb angewendet, Eingabefeld gesperrt → Nutzer blockiert.

**Reproduziert** (Szenario "Entfernen"): Total blieb CHF 22.70, Feld disabled, Folgeklicks unmöglich.

**Fix:** Ein einziger zustandsbasierter Handler (`if (aktuellerRabatt) entfernen() else einloesen()`), `btn.onclick`-Zuweisungen entfernt. CSP-konform (kein inline-Handler).

## Änderungen

| Datei | Änderung |
|---|---|
| `templates/base.html` | Cache-Busting `?v={{ app_version }}` an `cart.js` + `app.css` |
| `templates/checkout.html` | Ein zustandsbasierter Klick-Handler statt addEventListener+onclick-Mix |
| `tests/test_static_cache_busting.py` | Neuer Regressionstest (TDD) |
| `docs/user-stories-testplan.md` | Story 14, Schritte 16–17 (Entfernen + erneut einlösen) |

## Verifikation

- 257 Tests grün, Ruff sauber
- Browser-Repro nach Fix: Einlösen ✓, Entfernen räumt sauber auf (Total zurück, Feld entsperrt) ✓, erneutes Einlösen ✓, keine Konsolenfehler
- superpowers Code-Review: **Ready to merge — Yes**, keine Critical/Important

🤖 Generated with [Claude Code](https://claude.com/claude-code)