### PR TITLE
docs: Testplan-Warenkorbszenario auf 4 Produkte aktualisieren (#140)

### DIFF
--- a/docs/user-stories-testplan.md
+++ b/docs/user-stories-testplan.md
@@ -120,10 +120,10 @@
 
 | Schritt | Aktion | Erwartetes Ergebnis |
 |---------|--------|---------------------|
-| [ ] 1 | Alle 3 Produkte in den Warenkorb legen | Zähler zeigt 3 |
-| [ ] 2 | Warenkorb öffnen | Alle 3 Produkte aufgelistet |
+| [ ] 1 | Alle 4 Produkte in den Warenkorb legen | Zähler zeigt 4 |
+| [ ] 2 | Warenkorb öffnen | Alle 4 Produkte aufgelistet (250ml, 500ml, 750ml, 3L) |
 | [ ] 3 | Menge von 250ml auf 5 erhöhen (+ klicken) | Menge 5, Zwischenpreis aktualisiert |
-| [ ] 4 | 750ml entfernen (Entfernen-Button) | Nur noch 250ml und 3L im Warenkorb |
+| [ ] 4 | 750ml entfernen (Entfernen-Button) | Nur noch 250ml, 500ml und 3L im Warenkorb |
 | [ ] 5 | Seite neu laden (F5) | Warenkorb bleibt erhalten (localStorage) |
 | [ ] 6 | Menge auf 1 verringern, dann nochmal - drücken | Produkt wird entfernt (Minimum ist 1) oder bleibt bei 1 |
 | [ ] 7 | Alle Produkte entfernen | Leerer Warenkorb, Hinweis "Warenkorb ist leer" |


### PR DESCRIPTION
## Was

Story 5 (Warenkorb-Verwaltung) im manuellen End-to-End-Testplan referenzierte seit #135 (Aufnahme des 4. Produkts Olivenöl 500ml) noch das alte 3-Produkte-Sortiment. Zähler-, Listen- und Folgeschritte konsistent auf 4 Produkte nachgezogen.

## Änderungen
- Schritt 1: „Alle 3 Produkte" → „Alle 4 Produkte", Zähler 3 → 4
- Schritt 2: Liste um 500ml ergänzt, Produkte explizit benannt
- Schritt 4: nach Entfernen von 750ml bleiben „250ml, 500ml und 3L"

## Akzeptanzkriterien
- [x] Warenkorb-Szenario auf 4 Produkte (inkl. 500ml) aktualisiert
- [x] Erwartete Zähler-/Listenwerte und Folgeschritte konsistent
- [x] Keine weiteren „3 Produkte"-Reste im Testplan (Z. 87 „Alle 3 Optionen" = Zahlungsarten, korrekt)

Closes #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)
