### PR TITLE
docs: Admin-Bereich, Security-Header, CI/CD & SH-Zusammenarbeit dokumentieren

### DIFF
--- a/docs/arc42.md
+++ b/docs/arc42.md
@@ -10,7 +10,7 @@
 ## 1. Einführung und Ziele
 
 ### Was ist Olivalle?
-Olivalle ist ein Online-Shop für biologisches Olivenöl, importiert aus Andalusien, Spanien. Betrieben von einem Einzelunternehmer in der Schweiz — live auf [olivalle.ch](https://olivalle.ch) seit April 2026 (aktuell v1.3.5).
+Olivalle ist ein Online-Shop für biologisches Olivenöl, importiert aus Andalusien, Spanien. Betrieben von einem Einzelunternehmer in der Schweiz — live auf [olivalle.ch](https://olivalle.ch) seit April 2026 (aktuell v1.3.7).
 
 ### Produkte
 | Produkt | Preis |
@@ -184,6 +184,34 @@ static/                  # CSS, JS, Bilder
 ├── js/
 └── img/
 ```
+
+### Administrationsbereich
+
+Der Shopbetreiber verwaltet den gesamten Betrieb über einen passwortgeschützten Admin-Bereich (`/admin/*`). Er ersetzt den früheren manuellen Prozess (Tally-Formular + manuelle Rechnungen) vollständig.
+
+**Authentifizierung & Zugriffsschutz**
+
+- Login über ein einzelnes, bcrypt-gehashtes Passwort (`app/services/auth_service.py`) — kein Klartext im Code, Konfiguration via Umgebungsvariable `ADMIN_CREDENTIALS`.
+- Session über ein signiertes Cookie (itsdangerous); jede Admin-Seite prüft die gültige Session und leitet sonst auf `/admin/login` um.
+- Brute-Force-Schutz: Lockout nach 5 Fehlversuchen (`BruteForceGuard`), zusätzlich Rate-Limit 5/Min auf `/admin/login`.
+- CSRF-Schutz auf allen Admin-POST-Routen, Token an `sha256(admin_session)` gebunden (siehe §8 Sicherheit).
+
+**Funktionen & Routen**
+
+| Bereich | Route | Aufgabe |
+|---|---|---|
+| Login / Logout | `GET/POST /admin/login`, `POST /admin/logout` | Anmeldung, Abmeldung |
+| Dashboard | `GET /admin/` | KPI-Kacheln (offene Bestellungen, Monatsumsatz, Bestellungen heute — in Europe/Zurich gerechnet) + Bestellliste mit Filter (Status, Datum, Suche) |
+| Bestelldetail | `GET /admin/bestellungen/{id}` | Kundendaten, Positionen, Verlauf |
+| Statuswechsel | `POST /admin/bestellungen/{id}/status` | Status ändern; löst passende Status-E-Mail aus (siehe unten) |
+| Admin-Notiz | `POST /admin/bestellungen/{id}/notiz` | Interne Notiz zur Bestellung erfassen |
+| Produktverwaltung | `GET /admin/produkte` | Produktübersicht inkl. inaktiver Produkte |
+| Aktionspreise | `GET/POST /admin/produkte/{id}/aktion` | Aktionspreis setzen/entfernen (siehe §8 Aktionspreise) |
+| Rabattcodes | `GET /admin/rabattcodes`, `GET/POST /admin/rabattcodes/neu`, `GET/POST /admin/rabattcodes/{id}/bearbeiten` | Rabattcodes anlegen, bearbeiten, deaktivieren |
+
+**Bestellstatus.** Eine Bestellung durchläuft die Stati `neu → bezahlt → in_bearbeitung → versendet`/`abholbereit → abgeschlossen` (plus `storniert`). Beim Statuswechsel versendet `sende_status_email()` automatisch die passende Kunden-E-Mail (z. B. `zahlungseingang`, `versandbestaetigung`, `abholbereit`).
+
+**Audit-Log.** Sicherheits- und änderungsrelevante Admin-Aktionen (Login, Statuswechsel, Aktions- und Rabattcode-Änderungen) werden mit Zeitstempel und Client-IP in der Tabelle `admin_log` protokolliert (`app/repositories/admin_repo.py`). Damit sind Admin-Eingriffe nachvollziehbar. Eine Lese-UI für das Log existiert bewusst (noch) nicht — die Einsicht erfolgt bei Bedarf direkt über die Datenbank (YAGNI für den Ein-Personen-Betrieb).
 
 ---
 

--- a/docs/ci-cd-und-versionierung.md
+++ b/docs/ci-cd-und-versionierung.md
@@ -1,0 +1,70 @@
+[← Übersicht](index.md)
+
+# CI/CD & Versionierung
+
+Wie aus einem Push auf `main` ein Deployment auf fly.io wird, wie die Versionsnummer entsteht und wie Datenbank-Migrationen ablaufen.
+
+## Pipeline auf einen Blick
+
+Ein Push auf `main` löst den Workflow `.github/workflows/deploy.yml` aus. Er besteht aus drei aufeinander aufbauenden Jobs:
+
+```mermaid
+graph LR
+    Push["Push auf main"] --> Test["test<br/>pytest (uv)"]
+    Test -->|grün| Build["build<br/>Docker → GHCR<br/>APP_VERSION berechnen"]
+    Build --> Deploy["deploy<br/>flyctl deploy<br/>+ Git-Tag setzen"]
+    Test -->|rot| Stop["Pipeline stoppt"]
+```
+
+- **`test`** — installiert Dependencies via `uv sync --extra dev` und führt `pytest` aus. Schlägt ein Test fehl, stoppt die Pipeline (`build` hat `needs: test`).
+- **`build`** — baut das Docker-Image, pusht es nach GHCR (`ghcr.io/konstantinniedermann/olivalle`) und berechnet die App-Version (siehe unten). Die Version geht als Build-Arg `APP_VERSION` ins Image.
+- **`deploy`** — deployt das gebaute Image mit `flyctl deploy --image …` auf fly.io, schreibt eine Job-Summary und setzt **nach erfolgreichem Deploy** den Git-Tag.
+
+**Trigger:** `push` auf `main` sowie manuell via `workflow_dispatch`.
+**Concurrency:** `group: deploy`, `cancel-in-progress: true` — bei schnell aufeinanderfolgenden Pushes wird der ältere Lauf abgebrochen, damit immer der letzte Stand deployt wird.
+
+## Alle Workflows
+
+| Workflow | Trigger | Aufgabe |
+|---|---|---|
+| `deploy.yml` | Push auf `main`, manuell | Test → Build → Deploy auf fly.io + Git-Tag |
+| `lint.yml` | Pull Request + Push auf `main` | Ruff-Check + Format-Check (Qualitätsgate) |
+| `docs.yml` | Push auf `main` mit Änderungen unter `docs/**` | MkDocs-Site bauen und auf GitHub Pages deployen |
+| `monitor-uptime.yml` | alle 10 min (Cron), manuell | HTTP-Erreichbarkeit prüfen, Ping an Healthchecks.io |
+| `monitor-tls.yml` | täglich (Cron), manuell | TLS-Zertifikat-Restlaufzeit prüfen (Alarm < 30 Tage) |
+| `backup-check.yml` | täglich (Cron), manuell | Litestream-Backup-Heartbeat prüfen |
+
+Alle `uses:`-Einträge sind auf 40-stellige Commit-SHAs gepinnt (Schutz gegen Tag-Mutation, OWASP CICD-SEC-4) und werden via Dependabot wöchentlich aktualisiert (`.github/dependabot.yml`).
+
+## Versionierung
+
+**Schema:** `v{MINOR}.{PATCH}` (z. B. `v1.3.7`) — adaptiert vom Munica-Projekt.
+
+- **MINOR** steht in `pyproject.toml` (`version = "1.3"`) und wird manuell erhöht, wenn ein grösserer Funktionsblock fertig ist.
+- **PATCH** berechnet die CI automatisch: Anzahl bereits existierender Git-Tags `v{MINOR}.*` + 1.
+- Damit die Tag-Zählung stimmt, checkt der `build`-Job mit `fetch-depth: 0` aus (sonst sind ältere Tags nicht sichtbar).
+- **Fail-safe:** Der Git-Tag wird bewusst **erst nach** erfolgreichem Deploy gesetzt. Schlägt das Deploy fehl, bleibt der PATCH-Zähler unverändert und der nächste Push verwendet dieselbe Nummer erneut.
+
+**Sichtbarkeit der Version zur Laufzeit:** Das Build-Arg `APP_VERSION` wird im `Dockerfile` zur Umgebungsvariable, `app/config.py` liest sie als `app_version` (Default `"dev"`), und `app/templating.py` macht sie als globale Jinja2-Variable verfügbar. Der Footer (`templates/base.html`) zeigt sie an — so ist im Live-Shop jederzeit erkennbar, welcher Stand deployt ist. (Ein manueller `flyctl deploy` ohne `--build-arg APP_VERSION=…` zeigt deshalb `dev` im Footer — der CI-Deploy ist der Normalweg.)
+
+## Releases statt CHANGELOG.md
+
+Es gibt **bewusst keine** `CHANGELOG.md` im Repo. Die Release-Notes werden stattdessen als **GitHub Releases** kuratiert — und zwar nur bei einem MINOR-Bump (z. B. [v1.3 — Aktionspreise](https://github.com/konstantinniedermann/olivalle-webshop/releases)). Jeder Patch-Deploy erzeugt einen Git-Tag, aber kein eigenes Release; die feingranulare Historie liegt in den Git-Tags und in den geschlossenen GitHub Issues. Das hält den Pflegeaufwand für einen Ein-Personen-Betrieb gering, ohne Nachvollziehbarkeit zu verlieren.
+
+> **Bekannte Abweichung von der ursprünglichen Spec:** Die Versioning-Spec sah für `/health` zusätzlich ein `version`-Feld vor. Implementiert ist aktuell nur `{"status": "ok"}` (mit DB-Check). Da die Version bereits im Footer und über die Git-Tags sichtbar ist, hat das `version`-Feld im Health-Check niedrige Priorität.
+
+## Datenbank-Migrationen
+
+SQLite kennt keinen Migrations-Service — der Mechanismus ist bewusst minimal in `app/database.py` (`init_db()`) gelöst und läuft bei **jedem** Container-Start:
+
+1. **SQL-Dateien** unter `migrations/` werden in sortierter Reihenfolge ausgeführt (`001_initial.sql`, `002_admin.sql`, `003_rabattcodes.sql`). Die Nummerierung `NNN_*.sql` bestimmt die Reihenfolge — neue Migrationen erhalten die nächste Nummer.
+2. **Idempotente Spalten-Ergänzungen** über `_add_column_if_not_exists()` — z. B. die Aktionspreis-Spalten. Dadurch ist ein erneuter Start gefahrlos: bereits existierende Spalten werden übersprungen.
+3. **Produkt-Seed** in `001_initial.sql` per UPSERT (`ON CONFLICT(id) DO UPDATE`). Wichtig: Der UPSERT aktualisiert nur die Katalog-Spalten — admin-editierbare Spalten (Aktionspreise) sind ausgenommen und überleben Neustarts (siehe [arc42 §8, Bug #137](arc42.md#aktionspreise-issue-134)).
+
+**Regel beim Schreiben neuer Migrationen:** Datei mit nächster laufender Nummer anlegen, Statements idempotent halten (`CREATE TABLE IF NOT EXISTS`, `_add_column_if_not_exists`), und keine admin-editierbaren Spalten in die Seed-UPSERT-Liste aufnehmen.
+
+## Voraussetzungen (einmalig eingerichtet)
+
+- GitHub-Secret `FLY_API_TOKEN` (via `fly tokens create deploy`).
+- GHCR-Zugriff automatisch über `GITHUB_TOKEN` (keine zusätzliche Konfiguration).
+- fly-Secrets (Stripe-, Brevo-Keys etc.) werden einmalig manuell via `fly secrets set` gesetzt — nicht über die Pipeline.

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,7 @@ Olivalle ersetzt einen manuellen Bestellprozess (Tally-Formular + manuelle Rechn
 2. **Lösung & Architektur** → [arc42](arc42.md) (Gesamtbild), [Systemarchitektur](systemarchitektur.md) (Komponenten), [Datenbankschema](datenbankschema.md) (Daten), [Bestellprozess](bestellprozess.md) (Ablauf).
 3. **Entscheidungen** → [ADR-Index](adr-index.md) — warum dieser Tech-Stack, dieses Backup, diese Anbieter.
 4. **Validierung** → [User Stories & Testplan](user-stories-testplan.md), [Security-Referenz](security.md).
-5. **Betrieb** → [Restore-Runbook](runbook-restore.md), [Incident-Runbook](runbook-incident.md), [Datenschutz (intern)](datenschutz.md).
+5. **Betrieb** → [CI/CD & Versionierung](ci-cd-und-versionierung.md), [Restore-Runbook](runbook-restore.md), [Incident-Runbook](runbook-incident.md), [Datenschutz (intern)](datenschutz.md).
 
 ## Alle Dokumente
 
@@ -21,7 +21,7 @@ Olivalle ersetzt einen manuellen Bestellprozess (Tally-Formular + manuelle Rechn
 | **Architektur** | [arc42](arc42.md) · [Systemarchitektur](systemarchitektur.md) · [Datenbankschema](datenbankschema.md) · [Bestellprozess](bestellprozess.md) |
 | **Entscheidungen** | [ADR-Index](adr-index.md) · [Tech-Stack](adr-tech-stack.md) · [Backup-Strategie](adr-backup-strategie.md) · [Domain-Registrar](adr-domain-registrar.md) · [E-Mail-Provider](adr-email-provider.md) |
 | **Validierung** | [User Stories & Testplan](user-stories-testplan.md) · [Security](security.md) |
-| **Betrieb** | [Restore-Runbook](runbook-restore.md) · [Incident-Runbook](runbook-incident.md) · [Datenschutz (intern)](datenschutz.md) |
+| **Betrieb** | [CI/CD & Versionierung](ci-cd-und-versionierung.md) · [Restore-Runbook](runbook-restore.md) · [Incident-Runbook](runbook-incident.md) · [Datenschutz (intern)](datenschutz.md) |
 | **Rechtliches** | [AGB](legal/agb.md) · [Datenschutzerklärung](legal/datenschutz.md) · [Impressum](legal/impressum.md) |
 | **Projekt** | [Status & Historie](projekt-status.md) |
 

--- a/docs/projekt-status.md
+++ b/docs/projekt-status.md
@@ -4,7 +4,7 @@
 
 **Zweck:** Dieses Diagramm zeigt die abgeschlossenen Entwicklungsphasen (Pre-Launch) und den aktuellen Stand des Live-Betriebs.
 
-**Stand:** Live auf [olivalle.ch](https://olivalle.ch) seit April 2026, aktuell v1.3.5. Phasen 0–3 abgeschlossen, Phase 4 (laufender Betrieb & Feinschliff) aktiv.
+**Stand:** Live auf [olivalle.ch](https://olivalle.ch) seit April 2026, aktuell v1.3.7. Phasen 0–3 abgeschlossen, Phase 4 (laufender Betrieb & Feinschliff) aktiv.
 
 ```mermaid
 graph TD
@@ -31,3 +31,23 @@ graph TD
 - **Phase 4 — Betrieb (aktiv)** — Rabattcodes/Aktionspreise, Monitoring und Dokumentation.
 
 **Ausblick:** Offene Aufgaben werden über [GitHub Issues](https://github.com/konstantinniedermann/olivalle-webshop/issues) verwaltet (Historie unter Milestones).
+
+## Versionen & Changelog
+
+Es gibt bewusst keine `CHANGELOG.md` (Begründung: [CI/CD & Versionierung](ci-cd-und-versionierung.md#releases-statt-changelogmd)). Die kuratierten Release-Notes liegen als [GitHub Releases](https://github.com/konstantinniedermann/olivalle-webshop/releases) vor (pro MINOR-Bump, z. B. *v1.3 — Aktionspreise*, *v1.2.1 — Backup, Monitoring & Operations-Hardening*, *v1.1.4 — Production + CI-Hardening*). Jeder Patch-Deploy erzeugt zusätzlich einen Git-Tag `v{MINOR}.{PATCH}`.
+
+## Stakeholder-Zusammenarbeit
+
+Das Projekt wurde nicht im stillen Kämmerlein gebaut, sondern in laufender Abstimmung mit dem Auftraggeber (Stakeholder, im Folgenden „SH") — einem Einzelunternehmer, der Olivalle betreibt. Der SH ist gleichzeitig der spätere Betreiber des Shops. Über den gesamten Projektverlauf wurden Anforderungen gemeinsam geklärt, fachliche Inhalte vom SH eingeholt und mehrere Entscheidungen durch den SH gestützt oder ausgelöst. Beispiele, die im Repo öffentlich nachvollziehbar sind:
+
+| Thema | SH-Beitrag | Beleg |
+|---|---|---|
+| E-Mail-Provider | SH fragte aktiv eine Alternative mit EU-Datenstandort an → Wechsel zu Brevo | [ADR E-Mail-Provider](adr-email-provider.md) („Beteiligte: SH, KN") |
+| Domain-Registrar | Deutschsprachiges Interface als SH-Anforderung in die Bewertung eingeflossen | [ADR Domain-Registrar](adr-domain-registrar.md) |
+| Produktinhalte | Produkttexte, -bilder und Herkunftsangaben vom SH eingeholt | Issues [#38](https://github.com/konstantinniedermann/olivalle-webshop/issues/38), [#136](https://github.com/konstantinniedermann/olivalle-webshop/issues/136) |
+| Abholung / Versand | Abholadresse und Versandlogik mit SH abgestimmt; „Bezahlung bei Abholung" als gewünschte Option | Issues [#37](https://github.com/konstantinniedermann/olivalle-webshop/issues/37), [#59](https://github.com/konstantinniedermann/olivalle-webshop/issues/59) |
+| Go-Live-Freigabe | Smoke-Tests gemeinsam mit SH, formale Freigabe vor Launch | Issue [#67](https://github.com/konstantinniedermann/olivalle-webshop/issues/67) |
+| Produktseite / Texte | Textüberarbeitung und Lebensmittel-Deklaration auf Wunsch / mit SH | Issues [#102](https://github.com/konstantinniedermann/olivalle-webshop/issues/102), [#100](https://github.com/konstantinniedermann/olivalle-webshop/issues/100) |
+| Rechtliches | Datenschutzerklärung (revDSG-konform) abgestimmt | Issue [#69](https://github.com/konstantinniedermann/olivalle-webshop/issues/69) |
+
+Architektur- und Tech-Entscheidungen sind zusätzlich in den [ADRs](adr-index.md) festgehalten — dort ist jeweils vermerkt, wer beteiligt war.

--- a/docs/security.md
+++ b/docs/security.md
@@ -17,6 +17,24 @@ Faktische Bestandsaufnahme der im Code umgesetzten Maßnahmen (kein Vollaudit):
 - **Secrets:** ausschließlich via Umgebungsvariablen / `fly secrets`; nichts im Repo (`.env` gitignored).
 - **Transport:** HTTPS erzwungen durch fly.io.
 
+## Security-Header im Detail
+
+Alle Antworten erhalten Security-Header über `SecurityHeadersMiddleware` (`app/middleware/security_headers.py`). Pro Request wird eine frische CSP-Nonce erzeugt und für Inline-Scripts verwendet (kein `unsafe-eval`, kein `unsafe-inline` bei `script-src`).
+
+| Header | Wert | Zweck |
+|---|---|---|
+| `Content-Security-Policy` | `default-src 'self'`; `script-src 'self' 'nonce-…' https://js.stripe.com`; `style-src 'self' 'unsafe-inline' https://fonts.googleapis.com`; `img-src 'self' data:`; `font-src 'self' https://fonts.gstatic.com data:`; `connect-src 'self' https://api.stripe.com`; `frame-src https://js.stripe.com https://hooks.stripe.com`; `frame-ancestors 'none'`; `base-uri 'self'`; `form-action 'self' https://checkout.stripe.com` | XSS-/Injection-Schutz; nur eigene Quellen + Stripe erlaubt |
+| `Strict-Transport-Security` | `max-age=31536000; includeSubDomains` (nur über HTTPS) | Erzwingt HTTPS im Browser für ein Jahr |
+| `X-Frame-Options` | `DENY` | Clickjacking-Schutz (zusätzlich zu `frame-ancestors 'none'`) |
+| `X-Content-Type-Options` | `nosniff` | Verhindert MIME-Type-Sniffing |
+| `Referrer-Policy` | `strict-origin-when-cross-origin` | Begrenzt weitergegebene Referrer-Informationen |
+
+**Hintergrund:** Tailwind wird zur Build-Zeit kompiliert (Issue #88), Inline-Scripts laufen über Nonces (Issue #89) — dadurch kommt die CSP ohne `unsafe-eval` aus. Stripe-Domains sind explizit erlaubt, weil Checkout und Webhook-Frames darüber laufen.
+
+## Health-Check
+
+Der Endpunkt `GET /health` (`app/main.py`) prüft aktiv die Datenbank-Erreichbarkeit (`SELECT 1`) und antwortet bei Fehler mit HTTP 503. Er dient dem fly.io-internen Self-Heal und dem externen Uptime-Monitoring (siehe [CI/CD & Versionierung](ci-cd-und-versionierung.md)).
+
 ## Template-XSS-Audit
 
 **Stand:** 2026-04-07

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,6 +42,7 @@ nav:
     - User Stories & Testplan: user-stories-testplan.md
     - Security: security.md
   - Betrieb:
+    - CI/CD & Versionierung: ci-cd-und-versionierung.md
     - Restore-Runbook: runbook-restore.md
     - Incident-Runbook: runbook-incident.md
     - Datenschutz (intern): datenschutz.md


### PR DESCRIPTION
## Kontext

Gesamtheitlicher Doku-Vollständigkeits-Audit (Soll/Ist-Abgleich Doku gegen Code + History). Die **direkt & risikoarm ergänzbaren** Lücken wurden bereits behoben (siehe PR zu Branch `docs/admin-security-cicd-erweiterung`):

- arc42: neuer Abschnitt **Administrationsbereich** (Auth, alle Admin-Routen, Status-Mails, Audit-Log)
- security.md: vollständige **Security-Header-Tabelle** (CSP-Direktiven, HSTS, X-Frame-Options, Referrer-Policy) + `/health`-DB-Check
- neue Seite **CI/CD & Versionierung** (Pipeline, Versionsschema, Workflows, Migrations-Mechanismus)
- projekt-status: **Stakeholder-Zusammenarbeit** dokumentiert + Changelog-/Releases-Verweis
- Versions-Drift korrigiert (v1.3.5 → v1.3.7)

Dieses Issue sammelt die **verbleibenden, grösseren / klärungsbedürftigen** Erkenntnisse.

## Offene Punkte

---
Schliesst die direkt ergänzbaren Doku-Lücken aus dem Gesamt-Audit. Verbleibende Punkte: #144.
Gate: `mkdocs build --strict` läuft fehlerfrei.

🤖 Generated with [Claude Code](https://claude.com/claude-code)