### PR TITLE
docs: README straffen, Pages prominent, SECURITY.md als Melde-Policy (#146)

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,39 @@
+# Security Policy
+
+Olivalle ist der produktive Webshop eines Schweizer Einzelunternehmers, betrieben
+als Hobby-/Einzelprojekt. Verantwortungsvolle Meldungen von Sicherheitslücken sind
+sehr willkommen.
+
+## Geltungsbereich
+
+Diese Policy deckt den Code in diesem Repository und die Live-Anwendung unter
+[olivalle.ch](https://olivalle.ch) ab. Drittanbieter-Dienste (Stripe, Brevo, fly.io,
+Tigris) bitte direkt bei deren eigenen Sicherheitsstellen melden.
+
+## Eine Sicherheitslücke melden
+
+Bitte **keine öffentlichen GitHub-Issues** für Sicherheitslücken eröffnen — das würde
+das Problem offenlegen, bevor es behoben ist.
+
+Stattdessen über GitHubs vertraulichen Kanal:
+
+➡️ **[Privately report a vulnerability](https://github.com/konstantinniedermann/olivalle-webshop/security/advisories/new)**
+(Repo → Reiter **Security** → **Report a vulnerability**)
+
+Hilfreich für eine schnelle Einschätzung:
+
+- Beschreibung der Lücke und der betroffenen Stelle (URL, Endpunkt, Datei)
+- Schritte zur Reproduktion oder ein Proof of Concept
+- Mögliche Auswirkung (was könnte ein Angreifer erreichen?)
+
+## Was du erwarten kannst
+
+Dies ist ein Einzelprojekt ohne dediziertes Security-Team — Reaktion erfolgt nach
+bestem Bemühen (*best effort*), keine garantierten Fristen. In der Regel:
+
+- **Eingangsbestätigung:** innerhalb weniger Tage
+- **Erste Einschätzung:** sobald es die Zeit erlaubt
+- **Behebung:** je nach Schweregrad priorisiert
+
+Verantwortungsvolle Meldungen werden auf Wunsch in der Behebung anerkannt. Bitte gib
+mir angemessene Zeit zur Behebung, bevor Details öffentlich gemacht werden.

--- a/README.md
+++ b/README.md
@@ -4,44 +4,17 @@ Webshop für biologisches Olivenöl aus Andalusien — live auf **[olivalle.ch](
 
 Ersetzt den bisherigen manuellen Bestellprozess (Tally-Formular) durch einen vollständigen Shop mit Kartenzahlung/TWINT, automatischer Bestellbestätigung per E-Mail und QR-Rechnung für Rechnungskäufer.
 
----
-
-## Tech-Stack
-
-| Bereich | Technologie |
-|---|---|
-| Backend | Python 3.13 + FastAPI |
-| Frontend | Jinja2 Templates + Tailwind CSS (lokaler Build) |
-| Datenbank | SQLite (persistentes fly.io Volume) |
-| Zahlungen | Stripe (Twint, Kreditkarte) |
-| QR-Rechnung | [`qrbill`](https://github.com/claudep/swiss-qr-bill) (Open Source) |
-| E-Mail | Brevo (Free Tier) |
-| Hosting | [fly.io](https://fly.io) — 1 Docker-Container, Region `cdg` |
-| Tests | pytest (Unit + Integration + E2E) |
-| CI | GitHub Actions — Ruff-Lint-Gate, SHA-gepinnte Actions, Dependabot |
-
-Entscheidungsgrundlagen siehe [`docs/arc42.md`](docs/arc42.md) und die ADRs unter [`docs/`](docs/).
+> 📖 **Vollständige Projektdokumentation → [olivalle-Doku auf GitHub Pages](https://konstantinniedermann.github.io/olivalle-webshop/)**
+>
+> Roter Faden Problem → Lösung → Architektur (arc42) → Validierung → Betrieb. Architektur, ADRs, Diagramme und Betriebs-Runbooks leben dort — dieses README bleibt bewusst schlank.
 
 ---
 
-## Backups & Wiederherstellung
+## Tech-Stack (Kurzform)
 
-Die SQLite-DB wird kontinuierlich via [Litestream](https://litestream.io)
-in einen Tigris-Bucket (EU-Multi-Region: Amsterdam + Frankfurt) repliziert.
-Im Katastrophenfall (Volume-Verlust) restored der Container automatisch
-beim Start. Eine tägliche GitHub Action prüft die Backup-Frische gegen
-Healthchecks.io (Alarm bei Stillstand > 25 h).
+Python 3.13 + FastAPI · Jinja2 + Tailwind CSS · SQLite · Stripe (Twint/Kreditkarte) · Brevo (E-Mail) · gehostet auf [fly.io](https://fly.io).
 
-- Architekturentscheidung: [`docs/adr-backup-strategie.md`](docs/adr-backup-strategie.md)
-- Restore-Anleitung: [`docs/runbook-restore.md`](docs/runbook-restore.md)
-
----
-
-## Projekt-Kontext
-
-Erstes eigenes Webprojekt im Rahmen des **CAS AI-Supported Software Engineering (AISE)** an der FFHS. Gebaut für einen Freund als Einzelunternehmer-Shop. Der gesamte Entwicklungsprozess lief unter Einsatz von **Claude Code** und einem formalen Agentic-Workflow (Brainstorming → Writing Plans → TDD → Code Review → Merge) über das [`superpowers`](https://github.com/obra/superpowers)-Plugin.
-
-Dokumentations-Philosophie: **arc42** für Architektur, **ADRs** für Entscheidungen mit Tragweite, **Mermaid** für Diagramme direkt im Markdown.
+Begründungen, Alternativen und die vollständige Tabelle: [`docs/adr-tech-stack.md`](docs/adr-tech-stack.md).
 
 ---
 
@@ -82,44 +55,11 @@ Eine Vorlage liegt in `.env.example`. Produktive Secrets werden nicht im Repo ge
 
 ---
 
-## Projektstruktur
+## Projekt-Kontext
 
-```
-app/              FastAPI-Anwendung (Routen, Services, Modelle)
-templates/        Jinja2-Templates (Shop, Checkout, Admin, E-Mails)
-static/           CSS (Tailwind-Output), Bilder, JS
-tests/            pytest — Unit, Integration, E2E
-migrations/       SQLite-Schema-Migrationen
-docs/             arc42-Architektur, ADRs, Bestellprozess, Rechtliches
-```
+Erstes eigenes Webprojekt im Rahmen des **CAS AI-Supported Software Engineering (AISE)** an der FFHS, gebaut für einen Freund als Einzelunternehmer-Shop. Der gesamte Entwicklungsprozess lief unter Einsatz von **Claude Code** und einem formalen Agentic-Workflow (Brainstorming → Plan → TDD → Code Review → Merge) über das [`superpowers`](https://github.com/obra/superpowers)-Plugin.
 
-Detail-Scopes für fokussierte Arbeit: siehe `CLAUDE.md`.
-
----
-
-## Dokumentation
-
-Die vollständige, navigierbare Projektdokumentation liegt als Doku-Site vor:
-
-➡️ **[olivalle-Doku (GitHub Pages)](https://konstantinniedermann.github.io/olivalle-webshop/)**
-
-Quelle der Doku: [`docs/`](docs/) — Einstieg über [`docs/index.md`](docs/index.md) (roter Faden: Problem → Lösung → Architektur → Validierung → Betrieb). Architektur nach **arc42**, Entscheidungen als **ADRs**, Diagramme als **Mermaid**.
-
----
-
-## Deployment
-
-Produktionsdeployment läuft über GitHub Actions nach `fly.io`:
-
-```bash
-fly deploy --build-arg APP_VERSION=vX.Y.Z   # manueller Deploy (ARG nötig, sonst Footer zeigt "dev")
-fly logs                                    # Live-Logs der Produktions-App
-fly ssh console                             # Shell in den Container
-```
-
-Produktiv bevorzugt via CI (Push auf `main`) deployen — die Version (`APP_VERSION`) wird dort automatisch aus `pyproject.toml` + Tag-Count berechnet und als Docker-Build-Arg gesetzt.
-
-Konfiguration: [`fly.toml`](fly.toml). Persistente Daten (SQLite-DB) liegen auf dem Volume `olivalle_data` unter `/data`.
+Projektstand, Architektur (inkl. Projektstruktur/Bausteinsicht), Deployment und Backup-Strategie sind vollständig in der [Doku-Site](https://konstantinniedermann.github.io/olivalle-webshop/) dokumentiert — Einstieg: [`docs/projekt-status.md`](docs/projekt-status.md), [`docs/arc42.md`](docs/arc42.md), [`docs/ci-cd-und-versionierung.md`](docs/ci-cd-und-versionierung.md) und [`docs/adr-backup-strategie.md`](docs/adr-backup-strategie.md).
 
 ---
 
@@ -130,3 +70,9 @@ Dies ist der **produktive Code eines realen Live-Shops** ([olivalle.ch](https://
 - **Code**: Entstanden im Rahmen des CAS AISE zu Lern- und Demonstrationszwecken. Keine OSS-Lizenz, alle Rechte vorbehalten. Studium zu Lernzwecken ist willkommen; Wiederverwendung bitte vorher anfragen.
 - **Inhalte** (Logo, Produktbilder, Produkttexte, Marke Olivalle, Domains): Eigentum des Inhabers. Nicht Teil der Code-Nutzung — dürfen ohne Zustimmung nicht kopiert, abgebildet oder anderweitig verwendet werden.
 - **Pull Requests**: Werden nicht angenommen. Für Fragen zum Projekt-Kontext Issues nutzen.
+
+---
+
+## Sicherheit
+
+Eine Sicherheitslücke gefunden? Bitte **nicht** als öffentliches Issue melden, sondern über [GitHubs „Private vulnerability reporting"](https://github.com/konstantinniedermann/olivalle-webshop/security/advisories/new) — Details in [`SECURITY.md`](.github/SECURITY.md).

--- a/docs/arc42.md
+++ b/docs/arc42.md
@@ -193,7 +193,7 @@ Der Shopbetreiber verwaltet den gesamten Betrieb über einen passwortgeschützte
 
 - Login über ein einzelnes, bcrypt-gehashtes Passwort (`app/services/auth_service.py`) — kein Klartext im Code, Konfiguration via Umgebungsvariable `ADMIN_CREDENTIALS`.
 - Session über ein signiertes Cookie (itsdangerous); jede Admin-Seite prüft die gültige Session und leitet sonst auf `/admin/login` um.
-- Brute-Force-Schutz: Lockout nach 5 Fehlversuchen (`BruteForceGuard`), zusätzlich Rate-Limit 5/Min auf `/admin/login`.
+- Brute-Force-Schutz: Lockout nach mehreren Fehlversuchen (`BruteForceGuard`), zusätzlich Rate-Limiting auf `/admin/login`.
 - CSRF-Schutz auf allen Admin-POST-Routen, Token an `sha256(admin_session)` gebunden (siehe §8 Sicherheit).
 
 **Funktionen & Routen**
@@ -303,8 +303,8 @@ Vor dem Push wird lokal `make lint-all` (Ruff-Check + Format-Check) und `make te
 - HTTPS überall (fly.io erzwingt SSL)
 - Stripe Webhook-Signatur verifizieren (kein direktes Vertrauen in Webhook-Daten)
 - CSRF-Schutz für alle POST-Formulare: Tokens an pro-Nutzer Identity gebunden — Admin-Routen an `sha256(admin_session)`, anonyme Routen an ein `csrf_id`-Cookie (Double-Submit). Tokens sind dadurch nicht universell wiederverwendbar (Issue #77).
-- Rate-Limit (in-memory, sliding window): 10 Requests/Min auf `/bestellen`, 5/Min auf `/admin/login`
-- BruteForceGuard auf `/admin/login` (Lockout nach 5 Fehlversuchen)
+- Rate-Limit (in-memory, sliding window) auf `/bestellen` und `/admin/login`
+- BruteForceGuard auf `/admin/login` (Lockout nach mehreren Fehlversuchen)
 - `.env`-Dateien nie ins Repository committen
 
 ### Aktionspreise (Issue #134)

--- a/docs/security.md
+++ b/docs/security.md
@@ -9,8 +9,8 @@ Querschnittsdokumentation zu Security-relevanten Entscheidungen und Audits.
 Faktische Bestandsaufnahme der im Code umgesetzten Maßnahmen (kein Vollaudit):
 
 - **CSRF-Schutz:** Token-basiert für alle Formulare, an pro-Nutzer Identity gebunden (`app/csrf.py`).
-- **Rate-Limiting:** In-memory Sliding-Window auf `/bestellen` (10/Min) und Admin-Login (5/Min) (`app/services/rate_limit.py`).
-- **Brute-Force-Schutz:** Lockout nach 5 Fehlversuchen auf `/admin/login`.
+- **Rate-Limiting:** In-memory Sliding-Window aktiv auf `/bestellen` und Admin-Login (`app/services/rate_limit.py`).
+- **Brute-Force-Schutz:** Lockout nach mehreren Fehlversuchen auf `/admin/login`.
 - **Security-Header:** gesetzt via Middleware (`app/middleware/security_headers.py`), inkl. CSP ohne `unsafe-eval`.
 - **Admin-Auth:** bcrypt-gehashtes Passwort, kein Klartext im Code (`app/services/auth_service.py`).
 - **Stripe-Webhooks:** Signaturprüfung, kein blindes Vertrauen in Webhook-Daten (`app/routers/webhooks.py`).


### PR DESCRIPTION
Setzt Issue #146 um (entblockt, da #144 gemergt ist).

## Geprüft: kein Einfluss von #144
#144 hat das README nicht angefasst und in `security.md` nur neue Abschnitte ergänzt — die für #146 relevanten Schwellenwert-Zeilen blieben unverändert. Alle drei Teile waren unverändert umsetzbar.

## Änderungen
**A) README gestrafft (133 → 92 Zeilen)**
- Pages-Callout (Blockquote + Pfeil) direkt nach dem Intro statt am Ende
- Tech-Stack auf 1-Zeilen-Kurzform (Detail → `adr-tech-stack.md`)
- Backups/Projektstruktur/Deployment ausgelagert → 1-Zeilen-Verweise (kein Info-Verlust, alle Ziele in Pages-Doku verifiziert)
- neue Brückensektion „Sicherheit" → Melde-Policy

**C1) `.github/SECURITY.md` als Responsible-Disclosure-Policy**
- Scope, Melde-Weg (GitHub Private Vulnerability Reporting), keine öffentlichen Issues, best-effort-Reaktionszeit
- Private Vulnerability Reporting im Repo aktiviert (`{"enabled":true}`)
- `docs/security.md` bleibt interne Posture-Doku

**C2) Exakte Schwellenwerte generalisiert**
- `docs/security.md` + öffentliches `docs/arc42.md` (breiter Sweep): „10/Min, 5/Min" → „aktiv", „5 Fehlversuche" → „mehrere"
- `BruteForceGuard` (Code-Fakt) erhalten; `superpowers/specs` unangetastet (nicht öffentlich)

## Gates
- `mkdocs build --strict` grün
- alle README-Linkziele verifiziert
- Code-Review (Subagent): Ready to merge, keine Critical/Important

## Offen nach Merge
- Security-Reiter prüfen: zeigt die neue Melde-Policy (erst nach Merge auf `main` sichtbar)

Closes #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)
