### PR TITLE
fix: deploy.yml — reine Doku-Commits triggern keinen App-Deploy mehr

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,15 @@ name: Deploy olivalle
 on:
   push:
     branches: [main]
+    # Reine Doku-Änderungen brauchen keinen App-Deploy (kein Runtime-Einfluss,
+    # die App serviert keine .md-Dateien). Pages-Deploy läuft separat über docs.yml.
+    # paths-ignore greift nur, wenn ALLE geänderten Dateien matchen — gemischte
+    # Commits (Code + Doku) deployen weiterhin. workflow_dispatch ignoriert den Filter.
+    paths-ignore:
+      - "docs/**"
+      - "**.md"
+      - "mkdocs.yml"
+      - ".github/workflows/docs.yml"
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
Folgt auf #146 — behebt den dort beobachteten Punkt: `deploy.yml` hatte keinen `paths`-Filter, daher löste jeder `main`-Push (auch reine Doku-Commits) den vollen App-Deploy + Patch-Tag aus.

## Änderung
`paths-ignore` unter dem `push`-Trigger ergänzt:
- `docs/**`, `**.md`, `mkdocs.yml`, `.github/workflows/docs.yml`

## Warum sicher
- **`paths-ignore` (nicht `paths`):** überspringt nur, wenn *alle* geänderten Dateien matchen → gemischte Commits (Code + Doku) deployen weiterhin; unbekannte Pfade deployen im Zweifel.
- **Kein Runtime-Einfluss:** die App serviert/liest zur Laufzeit keine `.md`-Dateien (FastAPI + Templates/Static).
- **Pages-Deploy unberührt:** `docs.yml` hat einen eigenen `paths`-Filter und läuft bei Doku-Änderungen weiter.
- **`workflow_dispatch`** ignoriert den Filter → manueller Deploy jederzeit möglich.

## Effekt
Reine Doku-PRs bumpen die App-Version nicht mehr unnötig (v1.3.5→v1.3.12 stammte grösstenteils aus Doku-PRs). Dieser PR selbst ändert `deploy.yml` (kein Doku-Pfad) → deployt einmalig und beweist, dass Nicht-Doku-Changes weiter deployen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
