### PR TITLE
docs: Betriebs-Stack (CI/CD, Backup/Recovery, Monitoring) in Tech-Stack aufnehmen

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ Ersetzt den bisherigen manuellen Bestellprozess (Tally-Formular) durch einen vol
 
 Python 3.13 + FastAPI · Jinja2 + Tailwind CSS · SQLite · Stripe (Twint/Kreditkarte) · Brevo (E-Mail) · gehostet auf [fly.io](https://fly.io).
 
-Begründungen, Alternativen und die vollständige Tabelle: [`docs/adr-tech-stack.md`](docs/adr-tech-stack.md).
+**Betrieb:** GitHub Actions (CI/CD) · pytest · Litestream → Tigris-Backup · `/health` + Healthchecks.io-Monitoring.
+
+Begründungen, Alternativen und die vollständige Tabelle (inkl. Betriebs-Stack): [`docs/adr-tech-stack.md`](docs/adr-tech-stack.md).
 
 ---
 

--- a/docs/adr-tech-stack.md
+++ b/docs/adr-tech-stack.md
@@ -20,6 +20,17 @@ Olivalle ersetzt einen manuellen Bestellprozess (Tally-Formular + manuelle Rechn
 | Hosting | fly.io (1 Docker-Container) | Günstig (~$2/Mt real), kommerziell erlaubt, einfaches Deploy |
 | E-Mail | Brevo | EU/DSG-konform, Free Tier deckt das Volumen (siehe [E-Mail-Provider-ADR](adr-email-provider.md)) |
 
+### Betrieb (Operations-Stack)
+
+Über die Anwendung hinaus gehören die Betriebs-Werkzeuge zum Stack — sie tragen den eigentlichen Projektzweck (zuverlässiger Betrieb bei minimalem Aufwand für eine Einzelperson). Details jeweils in eigenen Dokumenten:
+
+| Bereich | Wahl | Zweck / Verweis |
+|---|---|---|
+| CI/CD | GitHub Actions (Test → Docker-Build → fly-Deploy + Auto-Tag, Ruff-Lint-Gate, MkDocs → Pages) | Automatisiertes Deployment & Qualitäts-Gate; SHA-gepinnte Actions + Dependabot (siehe [CI/CD & Versionierung](ci-cd-und-versionierung.md)) |
+| Backup / Recovery | Litestream → Tigris (S3-kompatibel, EU: Amsterdam + Frankfurt) | Kontinuierliche SQLite-Replikation, Auto-Restore beim Container-Start (siehe [Backup-ADR](adr-backup-strategie.md), [Restore-Runbook](runbook-restore.md)) |
+| Monitoring | `/health` (DB-Check, HTTP 503 bei Fehler) + Healthchecks.io + GitHub-Actions-Probes (Uptime, TLS, Backup-Frische) | Früherkennung von Ausfällen (siehe [Incident-Runbook](runbook-incident.md), [Security](security.md)) |
+| Tests / Qualität | pytest (Unit + Integration + E2E), Ruff (Lint + Format) | Bestelllogik, Stripe-Webhook, API-Endpunkte abgedeckt |
+
 ## Verworfene Alternativen
 
 - **React/Next.js-SPA** — verworfen: zweiter Sprach-/Build-Kontext, für einen Anfänger und einen simplen Shop unnötige Komplexität (KISS/YAGNI). Server-rendered HTML genügt.

--- a/docs/adr-tech-stack.md
+++ b/docs/adr-tech-stack.md
@@ -27,7 +27,7 @@ Olivalle ersetzt einen manuellen Bestellprozess (Tally-Formular + manuelle Rechn
 | Bereich | Wahl | Zweck / Verweis |
 |---|---|---|
 | CI/CD | GitHub Actions (Test → Docker-Build → fly-Deploy + Auto-Tag, Ruff-Lint-Gate, MkDocs → Pages) | Automatisiertes Deployment & Qualitäts-Gate; SHA-gepinnte Actions + Dependabot (siehe [CI/CD & Versionierung](ci-cd-und-versionierung.md)) |
-| Backup / Recovery | Litestream → Tigris (S3-kompatibel, EU: Amsterdam + Frankfurt) | Kontinuierliche SQLite-Replikation, Auto-Restore beim Container-Start (siehe [Backup-ADR](adr-backup-strategie.md), [Restore-Runbook](runbook-restore.md)) |
+| Backup / Recovery | Litestream → Tigris (S3-kompatibel, EU-Region `eur`) | Kontinuierliche SQLite-Replikation, Auto-Restore beim Container-Start (siehe [Backup-ADR](adr-backup-strategie.md), [Restore-Runbook](runbook-restore.md)) |
 | Monitoring | `/health` (DB-Check, HTTP 503 bei Fehler) + Healthchecks.io + GitHub-Actions-Probes (Uptime, TLS, Backup-Frische) | Früherkennung von Ausfällen (siehe [Incident-Runbook](runbook-incident.md), [Security](security.md)) |
 | Tests / Qualität | pytest (Unit + Integration + E2E), Ruff (Lint + Format) | Bestelllogik, Stripe-Webhook, API-Endpunkte abgedeckt |
 


### PR DESCRIPTION
Folgt auf #146 — nimmt den Betriebs-Layer in die Tech-Stack-Übersicht auf. Bisher zeigten die Stack-Sichten nur den App-Stack; CI/CD, Backup/Recovery und Monitoring waren zwar in eigenen Dokumenten beschrieben, aber in der Stack-Sicht unsichtbar — obwohl sie den eigentlichen Projektzweck (zuverlässiger Betrieb bei minimalem Aufwand) tragen.

## Änderung
- **`docs/adr-tech-stack.md`** (kanonisch): neue Gruppe „Betrieb (Operations-Stack)" — CI/CD (GitHub Actions), Backup/Recovery (Litestream→Tigris), Monitoring (`/health` + Healthchecks.io + Probes), Tests/Qualität (pytest, Ruff). Jeweils mit Verweis aufs Detail-Doku (DRY — keine Duplikation, nur Stack-Sicht + Querverweise).
- **`README.md`** „Tech-Stack (Kurzform)": knappe Betriebs-Zeile ergänzt. Hält die #146-Straffung schlank und holt das dabei verlorene pytest/GitHub-Actions zurück.

## Gates
- `mkdocs build --strict` grün, alle Verweis-Links verifiziert
- Reiner Doku-Commit → löst dank #148 (paths-ignore) **keinen** App-Deploy aus, nur Pages rebuildet

🤖 Generated with [Claude Code](https://claude.com/claude-code)
