### PR TITLE
feat: Minor-Bump auf v1.4 (kuratiertes Release)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "olivalle"
-version = "1.3"
+version = "1.4"
 requires-python = ">=3.13"
 dependencies = [
     "fastapi>=0.115",


### PR DESCRIPTION
## Zweck
Minor-Bump `1.3` → `1.4` in `pyproject.toml`, um ein kuratiertes GitHub Release für den aktuellen Stand zu erzeugen. Der Merge nach `main` löst den Deploy aus und taggt automatisch `v1.4.1`.

## Inhalt seit v1.3 (52 Commits, thematisch)
- **Shop:** neue 500ml-Geschenkflasche, 4-Spalten-Grid, Produktkarten-Redesign, zweizeiliger Preis-Block
- **Fixes:** Rabattcode-Cache/Handler, Mermaid-v11-Parse-Fehler
- **Doku:** MkDocs-Site, arc42-Ausbau, Compliance (LIV/Tigris), Doku-Audit #150–#159
- **CI/Ops:** `paths-ignore` für Doku-Commits, Betriebs-Stack-Doku

## Bump-Gate (doku-audit)
✅ Bestanden — Audit #150–#159 heute geschlossen; Re-Verify (Versionen/Preise/Release-Modell) konsistent; keine offenen `[Doku-Audit:*]`-HOCH-Issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)