### PR TITLE
fix: Warenkorb-Flyout ohne innerHTML-Interpolation rendern

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -46,3 +46,9 @@ aktuell keine Stelle, an der Jinja2-Autoescape umgangen wird.
 `Markup()` prüfen, ob Userinput in den markupten String fliessen kann.
 Nur statische, vertrauenswürdige Strings markupen. Im Zweifel: stattdessen
 escapen lassen.
+
+**Client-seitig (JavaScript):** Nutzdaten (z.B. Produktnamen aus
+`localStorage` oder `data`-Attributen) nie per String-Interpolation in
+`innerHTML` rendern, sondern DOM-Knoten mit `createElement` +
+`textContent` bauen (Issue #166). `innerHTML = ""` zum Leeren eines
+Containers ist unbedenklich.

--- a/static/js/cart.js
+++ b/static/js/cart.js
@@ -97,16 +97,22 @@ function showCartFlyout() {
     const cart = getCart();
     if (cart.length === 0) return;
 
-    // Inhalt rendern
-    itemsContainer.innerHTML = cart
-        .map(
-            (item) =>
-                `<div class="flex justify-between text-stone-200">
-                    <span>${item.menge}\u00d7 ${item.name}</span>
-                    <span>CHF ${(item.preis * item.menge).toFixed(2)}</span>
-                </div>`
-        )
-        .join("");
+    // Inhalt rendern \u2014 textContent statt innerHTML, damit Produktnamen
+    // aus localStorage/DB nie als HTML interpretiert werden (#166)
+    itemsContainer.innerHTML = "";
+    cart.forEach((item) => {
+        const row = document.createElement("div");
+        row.className = "flex justify-between text-stone-200";
+
+        const nameEl = document.createElement("span");
+        nameEl.textContent = `${item.menge}\u00d7 ${item.name}`;
+
+        const priceEl = document.createElement("span");
+        priceEl.textContent = `CHF ${(item.preis * item.menge).toFixed(2)}`;
+
+        row.append(nameEl, priceEl);
+        itemsContainer.appendChild(row);
+    });
     totalEl.textContent = "CHF " + getCartTotal().toFixed(2);
 
     // Smooth einblenden


### PR DESCRIPTION
## Zusammenfassung
- `showCartFlyout()` baut die Flyout-Zeilen neu mit `document.createElement` + `textContent` statt Produktnamen per Template-String in `innerHTML` zu interpolieren (Defense-in-Depth zur CSP, Finding aus dem Refactoring-Audit)
- `docs/security.md`: Regel für client-seitiges DOM-XSS-freies Rendern ergänzt

## Verifikation
- Node-Smoke-Test mit DOM-Stub: XSS-Payload als Produktname (`<img src=x onerror=alert(1)>`) landet als reiner Text im `textContent`; Preis/Total unverändert korrekt
- Visuelles Markup identisch (gleiche Klassen, gleiche Spans, gleiches Format)
- 257 pytest-Tests grün, Ruff sauber, `mkdocs build --strict` sauber

## Review
superpowers Code-Review durchgeführt: keine Critical/Important-Findings. Minor-Follow-up (gleiche `innerHTML`-Interpolation in `templates/admin/bestellung_detail.html:524`, ohne realen Vektor da Status-Enum serverseitig fix) als Kommentar in #166 notiert.

Fixes #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)