### PR TITLE
fix: Fail-Fast-Prüfung der Produktionskonfig beim Container-Start (#161)

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -55,9 +55,11 @@ def pruefe_produktionskonfig(s: Settings | None = None) -> list[str]:
     """
     s = s or settings
     probleme: list[str] = []
-    if not s.secret_key or s.secret_key == "change-me":
-        probleme.append("SECRET_KEY ist nicht gesetzt (Default 'change-me' aktiv)")
-    if s.base_url.startswith("http://localhost"):
+    # startswith statt ==: faengt auch den Copy-Paste-Platzhalter
+    # "change-me-in-production" aus .env.example (public Repo!) ab.
+    if not s.secret_key or s.secret_key.startswith("change-me"):
+        probleme.append("SECRET_KEY ist nicht gesetzt (Platzhalter 'change-me…' aktiv)")
+    if s.base_url.startswith(("http://localhost", "http://127.0.0.1")):
         probleme.append("BASE_URL zeigt auf localhost (Stripe-Redirects brechen)")
     for feld in _PFLICHT_SECRETS:
         if not getattr(s, feld):

--- a/app/config.py
+++ b/app/config.py
@@ -33,3 +33,50 @@ class Settings(BaseSettings):
 
 
 settings = Settings()
+
+
+# Secrets/Konfig-Felder, die in Produktion gesetzt sein MUESSEN. Fehlen sie,
+# laeuft die App sonst mit unsicheren Defaults (secret_key) oder scheitert erst
+# spaet zur Laufzeit (leere Stripe-/Brevo-Keys) — beides schwer zu diagnostizieren.
+_PFLICHT_SECRETS = (
+    "stripe_secret_key",
+    "stripe_webhook_secret",
+    "brevo_api_key",
+    "admin_credentials",
+    "qr_iban",
+)
+
+
+def pruefe_produktionskonfig(s: Settings | None = None) -> list[str]:
+    """Prueft die Produktionskonfiguration und gibt eine Liste von Problemen zurueck.
+
+    Leere Liste bedeutet: alles gesetzt. Wird beim Container-Start aufgerufen
+    (siehe entrypoint.sh); lokal/in Tests wird sie nicht ausgefuehrt.
+    """
+    s = s or settings
+    probleme: list[str] = []
+    if not s.secret_key or s.secret_key == "change-me":
+        probleme.append("SECRET_KEY ist nicht gesetzt (Default 'change-me' aktiv)")
+    if s.base_url.startswith("http://localhost"):
+        probleme.append("BASE_URL zeigt auf localhost (Stripe-Redirects brechen)")
+    for feld in _PFLICHT_SECRETS:
+        if not getattr(s, feld):
+            probleme.append(f"{feld.upper()} ist leer")
+    return probleme
+
+
+def _cli_fail_fast() -> None:
+    """Entrypoint-Hook: bricht den Start ab, wenn Pflicht-Konfig fehlt."""
+    import sys
+
+    probleme = pruefe_produktionskonfig()
+    if probleme:
+        print("[config] Produktionskonfiguration unvollstaendig:", file=sys.stderr)
+        for p in probleme:
+            print(f"  - {p}", file=sys.stderr)
+        sys.exit(1)
+    print("[config] Produktionskonfiguration ok.")
+
+
+if __name__ == "__main__":
+    _cli_fail_fast()

--- a/docs/security.md
+++ b/docs/security.md
@@ -15,6 +15,7 @@ Faktische Bestandsaufnahme der im Code umgesetzten Maßnahmen (kein Vollaudit):
 - **Admin-Auth:** bcrypt-gehashtes Passwort, kein Klartext im Code (`app/services/auth_service.py`).
 - **Stripe-Webhooks:** Signaturprüfung, kein blindes Vertrauen in Webhook-Daten (`app/routers/webhooks.py`).
 - **Secrets:** ausschließlich via Umgebungsvariablen / `fly secrets`; nichts im Repo (`.env` gitignored).
+- **Fail-Fast-Konfigcheck:** Der Container bricht beim Start ab, wenn Pflicht-Secrets fehlen oder `SECRET_KEY` auf einem Platzhalter steht (`python -m app.config` in `entrypoint.sh`, Issue #161).
 - **Transport:** HTTPS erzwungen durch fly.io.
 
 ## Security-Header im Detail

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,9 +15,13 @@ if [ ! -f "$DB_PATH" ]; then
   }
 fi
 
-# 2) Migrationen (idempotent, auf Volume)
+# 2) Fail-Fast: Produktionskonfiguration pruefen (bricht bei fehlenden
+#    Pflicht-Secrets ab, statt mit unsicheren Defaults zu starten).
+python -m app.config
+
+# 3) Migrationen (idempotent, auf Volume)
 python -c 'from app.database import init_db; init_db()'
 
-# 3) Litestream als PID 1, uvicorn als ueberwachter Subprocess
+# 4) Litestream als PID 1, uvicorn als ueberwachter Subprocess
 exec litestream replicate -config /etc/litestream.yml -exec \
   "uvicorn app.main:app --host 0.0.0.0 --port 8000 --proxy-headers --forwarded-allow-ips=*"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,17 +7,19 @@ set -eu
 
 DB_PATH="${DATABASE_PATH:-/data/olivalle.db}"
 
-# 1) Auto-Restore bei leerem Volume
+# 1) Fail-Fast: Produktionskonfiguration pruefen (bricht bei fehlenden
+#    Pflicht-Secrets ab, statt mit unsicheren Defaults zu starten).
+#    Bewusst VOR dem Restore: bei Fehlkonfiguration soll der Container
+#    sofort abbrechen, ohne den Backup-Pfad anzufassen.
+python -m app.config
+
+# 2) Auto-Restore bei leerem Volume
 if [ ! -f "$DB_PATH" ]; then
   echo "[entrypoint] Keine DB gefunden — versuche Restore aus Tigris…"
   litestream restore -if-replica-exists -config /etc/litestream.yml "$DB_PATH" || {
     echo "[entrypoint] Kein Backup vorhanden (erstes Deployment) — frische DB."
   }
 fi
-
-# 2) Fail-Fast: Produktionskonfiguration pruefen (bricht bei fehlenden
-#    Pflicht-Secrets ab, statt mit unsicheren Defaults zu starten).
-python -m app.config
 
 # 3) Migrationen (idempotent, auf Volume)
 python -c 'from app.database import init_db; init_db()'

--- a/tests/test_config_fail_fast.py
+++ b/tests/test_config_fail_fast.py
@@ -32,9 +32,24 @@ def test_leerer_secret_key_wird_erkannt():
     assert any("SECRET_KEY" in p for p in probleme)
 
 
+def test_platzhalter_secret_key_wird_erkannt():
+    """Der Copy-Paste-Wert aus .env.example darf den Check nicht bestehen."""
+    probleme = pruefe_produktionskonfig(
+        _vollstaendige_settings(secret_key="change-me-in-production")
+    )
+    assert any("SECRET_KEY" in p for p in probleme)
+
+
 def test_localhost_base_url_wird_erkannt():
     probleme = pruefe_produktionskonfig(
         _vollstaendige_settings(base_url="http://localhost:8000")
+    )
+    assert any("BASE_URL" in p for p in probleme)
+
+
+def test_loopback_base_url_wird_erkannt():
+    probleme = pruefe_produktionskonfig(
+        _vollstaendige_settings(base_url="http://127.0.0.1:8000")
     )
     assert any("BASE_URL" in p for p in probleme)
 

--- a/tests/test_config_fail_fast.py
+++ b/tests/test_config_fail_fast.py
@@ -1,0 +1,53 @@
+"""Tests fuer die Produktions-Konfigurationspruefung (#161)."""
+
+from app.config import Settings, pruefe_produktionskonfig
+
+
+def _vollstaendige_settings(**overrides) -> Settings:
+    """Settings mit allen Pflichtfeldern gesetzt; overrides fuer Einzelfaelle."""
+    werte = {
+        "secret_key": "ein-echtes-langes-geheimnis",
+        "base_url": "https://olivalle.ch",
+        "stripe_secret_key": "sk_live_x",
+        "stripe_webhook_secret": "whsec_x",
+        "brevo_api_key": "brevo_x",
+        "admin_credentials": "inhaber:$2b$hash",
+        "qr_iban": "CH0000000000000000000",
+    }
+    werte.update(overrides)
+    return Settings(**werte)
+
+
+def test_vollstaendige_konfig_keine_probleme():
+    assert pruefe_produktionskonfig(_vollstaendige_settings()) == []
+
+
+def test_default_secret_key_wird_erkannt():
+    probleme = pruefe_produktionskonfig(_vollstaendige_settings(secret_key="change-me"))
+    assert any("SECRET_KEY" in p for p in probleme)
+
+
+def test_leerer_secret_key_wird_erkannt():
+    probleme = pruefe_produktionskonfig(_vollstaendige_settings(secret_key=""))
+    assert any("SECRET_KEY" in p for p in probleme)
+
+
+def test_localhost_base_url_wird_erkannt():
+    probleme = pruefe_produktionskonfig(
+        _vollstaendige_settings(base_url="http://localhost:8000")
+    )
+    assert any("BASE_URL" in p for p in probleme)
+
+
+def test_leeres_pflichtsecret_wird_erkannt():
+    probleme = pruefe_produktionskonfig(_vollstaendige_settings(brevo_api_key=""))
+    assert any("BREVO_API_KEY" in p for p in probleme)
+
+
+def test_mehrere_probleme_werden_gesammelt():
+    probleme = pruefe_produktionskonfig(
+        _vollstaendige_settings(
+            secret_key="change-me", stripe_secret_key="", admin_credentials=""
+        )
+    )
+    assert len(probleme) == 3


### PR DESCRIPTION
Closes #161

## Was

Der Container bricht beim Start ab, statt mit unsicheren Default-Secrets zu laufen:

- **`pruefe_produktionskonfig()`** in `app/config.py`: prüft `secret_key` (leer oder `change-me…`-Platzhalter, inkl. Copy-Paste-Wert aus `.env.example`), `base_url` (localhost/127.0.0.1) und die Pflicht-Secrets (`STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`, `BREVO_API_KEY`, `ADMIN_CREDENTIALS`, `QR_IBAN`).
- **`entrypoint.sh`**: `python -m app.config` als Schritt 1 (vor Litestream-Restore) — bei Fehlkonfiguration Exit 1, das fly-Deploy schlägt fehl und die alte Version läuft weiter.
- Lokal/Tests unverändert: der Check läuft nur im Container.

## Warum

Das Repo ist public — `secret_key = "change-me"` ist öffentlich bekannt. Ein Deployment ohne gesetztes `SECRET_KEY`-Secret würde Angreifern erlauben, Admin-Session- und CSRF-Tokens selbst zu signieren (HMAC mit bekanntem Key).

## Review

Code-Review durchgeführt; Important-Finding gefixt: exakter `== "change-me"`-Vergleich hätte den Platzhalter `change-me-in-production` aus `.env.example` durchgelassen → jetzt `startswith("change-me")` + Test.

## Tests

- 8 Unit-Tests in `tests/test_config_fail_fast.py`
- Gesamte Suite: 265 passed, `make lint-all` grün (inkl. shellcheck)

## Hinweis vor dem Merge

`fly secrets list` sollte die 7 geprüften Namen enthalten (`SECRET_KEY`, `BASE_URL`, `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`, `BREVO_API_KEY`, `ADMIN_CREDENTIALS`, `QR_IBAN`). Da der Shop live mit Stripe/Brevo/QR läuft, ist das Risiko eines False-Positive minimal — falls doch eines fehlt, schlägt nur das Deploy fehl (alte Version bleibt live).

🤖 Generated with [Claude Code](https://claude.com/claude-code)