### PR TITLE
fix: make lint-all prüft scripts/ analog CI (#164)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,8 +24,8 @@ format: ## Code formatieren (Ruff)
 	uv run ruff format .
 
 lint-all: ## Ruff-Check + Format-Check + shellcheck (gleich wie CI)
-	uv run ruff check app tests
-	uv run ruff format --check app tests
+	uv run ruff check app tests scripts
+	uv run ruff format --check app tests scripts
 	shellcheck entrypoint.sh
 
 shellcheck: ## Shell-Skripte statisch prüfen


### PR DESCRIPTION
Closes #164

## Was

`make lint-all` prüft jetzt denselben Scope wie das CI-Lint-Gate: `app tests scripts` (vorher nur `app tests`). Zeilengenaue Parität mit `.github/workflows/lint.yml` (ruff check + ruff format --check).

## Warum

Änderungen unter `scripts/` (check_backup.py, check_tls.py) bestanden lokal `make lint-all` und fielen erst in CI durch — Drift zwischen lokalem Gate und CI.

## Review

Code-Review durchgeführt: keine Findings, Ready to merge. Verifiziert: `uv run ruff check app tests scripts` → All checks passed, `ruff format --check` → 77 files already formatted. Merge-tree gegen main konfliktfrei.

Beobachtung fürs Protokoll (kein Blocker): CI-shellcheck scannt das ganze Repo, `lint-all` nur `entrypoint.sh` — aktuell äquivalent, da es das einzige Shell-Skript ist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)