### PR TITLE
fix: E-Mail-Versand fault-tolerant — Brevo-Ausfall kippt Bestellablauf nicht mehr (#162)

### DIFF
--- a/app/services/email_service.py
+++ b/app/services/email_service.py
@@ -9,6 +9,8 @@ from jinja2 import Environment, FileSystemLoader
 from app.config import settings
 from app.labels import VERSANDART_LABELS, ZAHLUNGSART_LABELS_EMAIL
 
+logger = logging.getLogger(__name__)
+
 brevo_client = Brevo(api_key=settings.brevo_api_key)
 
 TEMPLATE_DIR = Path(__file__).resolve().parent.parent.parent / "templates" / "emails"
@@ -55,20 +57,44 @@ def sende_bestellbestaetigung(
             }
         ]
 
-    result = brevo_client.transactional_emails.send_transac_email(**params)
-
-    if conn:
-        from app.repositories.admin_repo import log_eintrag_schreiben
-
-        log_eintrag_schreiben(
+    betreff = params["subject"]
+    try:
+        result = brevo_client.transactional_emails.send_transac_email(**params)
+    except Exception:
+        # Ein Brevo-Ausfall darf den Bestellablauf nicht kippen: die Bestellung
+        # ist zu diesem Zeitpunkt bereits persistiert. Fehler protokollieren
+        # (email_fehler), damit der Betreiber die Mail manuell nachsenden kann.
+        logger.exception("Bestellbestätigung konnte nicht gesendet werden: %s", betreff)
+        _log_email(
             conn,
-            admin_label="system",
-            aktion="email_ausgang",
-            details=f"An: {empfaenger} — Olivalle — Bestellbestätigung #{bestell_id}",
-            bestellung_id=bestell_id,
+            "email_fehler",
+            f"Versand fehlgeschlagen an: {empfaenger} — {betreff}",
+            bestell_id,
         )
+        return None
 
+    _log_email(conn, "email_ausgang", f"An: {empfaenger} — {betreff}", bestell_id)
     return result
+
+
+def _log_email(
+    conn: sqlite3.Connection | None,
+    aktion: str,
+    details: str,
+    bestellung_id: int,
+) -> None:
+    """Schreibt einen E-Mail-Logeintrag (email_ausgang / email_fehler), falls conn."""
+    if not conn:
+        return
+    from app.repositories.admin_repo import log_eintrag_schreiben
+
+    log_eintrag_schreiben(
+        conn,
+        admin_label="system",
+        aktion=aktion,
+        details=details,
+        bestellung_id=bestellung_id,
+    )
 
 
 # Mapping: Status → (Template-Datei, Betreff-Text)
@@ -87,8 +113,6 @@ _STATUS_EMAIL_CONFIG: dict[str, tuple[str, str]] = {
     ),
 }
 
-logger = logging.getLogger(__name__)
-
 
 def sende_status_email(
     bestellung_id: int,
@@ -100,7 +124,7 @@ def sende_status_email(
     if not config:
         return
 
-    from app.repositories.admin_repo import get_bestellung_detail, log_eintrag_schreiben
+    from app.repositories.admin_repo import get_bestellung_detail
 
     bestellung = get_bestellung_detail(conn, bestellung_id)
     if not bestellung:
@@ -133,23 +157,19 @@ def sende_status_email(
             subject=betreff,
             html_content=html,
         )
-
-        log_eintrag_schreiben(
-            conn,
-            admin_label="system",
-            aktion="email_ausgang",
-            details=f"An: {bestellung['email']} — {betreff}",
-            bestellung_id=bestellung_id,
-        )
     except Exception:
         logger.exception("Status-E-Mail konnte nicht gesendet werden: %s", betreff)
-        log_eintrag_schreiben(
+        _log_email(
             conn,
-            admin_label="system",
-            aktion="email_fehler",
-            details=f"Versand fehlgeschlagen an: {bestellung['email']} — {betreff}",
-            bestellung_id=bestellung_id,
+            "email_fehler",
+            f"Versand fehlgeschlagen an: {bestellung['email']} — {betreff}",
+            bestellung_id,
         )
+        return
+
+    _log_email(
+        conn, "email_ausgang", f"An: {bestellung['email']} — {betreff}", bestellung_id
+    )
 
 
 def sende_stakeholder_benachrichtigung(
@@ -179,22 +199,28 @@ def sende_stakeholder_benachrichtigung(
         rabattcode=rabattcode,
     )
 
-    result = brevo_client.transactional_emails.send_transac_email(
-        sender={"email": "bestellung@olivalle.ch", "name": "Olivalle"},
-        to=[{"email": "olivalle.olten@outlook.com"}],
-        subject=f"Neue Bestellung #{bestell_id}",
-        html_content=html,
-    )
-
-    if conn:
-        from app.repositories.admin_repo import log_eintrag_schreiben
-
-        log_eintrag_schreiben(
-            conn,
-            admin_label="system",
-            aktion="email_ausgang",
-            details=f"An: olivalle.olten@outlook.com — Neue Bestellung #{bestell_id}",
-            bestellung_id=bestell_id,
+    betreff = f"Neue Bestellung #{bestell_id}"
+    try:
+        result = brevo_client.transactional_emails.send_transac_email(
+            sender={"email": "bestellung@olivalle.ch", "name": "Olivalle"},
+            to=[{"email": "olivalle.olten@outlook.com"}],
+            subject=betreff,
+            html_content=html,
         )
+    except Exception:
+        logger.exception("Stakeholder-Mail konnte nicht gesendet werden: %s", betreff)
+        _log_email(
+            conn,
+            "email_fehler",
+            f"Versand fehlgeschlagen an: olivalle.olten@outlook.com — {betreff}",
+            bestell_id,
+        )
+        return None
 
+    _log_email(
+        conn,
+        "email_ausgang",
+        f"An: olivalle.olten@outlook.com — {betreff}",
+        bestell_id,
+    )
     return result

--- a/app/services/email_service.py
+++ b/app/services/email_service.py
@@ -30,40 +30,41 @@ def sende_bestellbestaetigung(
     rabattbetrag: float = 0,
     rabattcode: str = "",
 ) -> object:
-    template = env.get_template(template_name)
-    html = template.render(
-        kunde=kunde,
-        bestell_id=bestell_id,
-        positionen=positionen,
-        versandkosten=versandkosten,
-        total=total,
-        rabattbetrag=rabattbetrag,
-        rabattcode=rabattcode,
-    )
-
-    params: dict = {
-        "sender": {"email": "bestellung@olivalle.ch", "name": "Olivalle"},
-        "to": [{"email": empfaenger}],
-        "reply_to": {"email": "olivalle.olten@outlook.com"},
-        "subject": f"Olivalle — Bestellbestätigung #{bestell_id}",
-        "html_content": html,
-    }
-
-    if anhang:
-        params["attachment"] = [
-            {
-                "content": base64.b64encode(anhang).decode("utf-8"),
-                "name": f"rechnung-{bestell_id}.pdf",
-            }
-        ]
-
-    betreff = params["subject"]
+    betreff = f"Olivalle — Bestellbestätigung #{bestell_id}"
     try:
+        template = env.get_template(template_name)
+        html = template.render(
+            kunde=kunde,
+            bestell_id=bestell_id,
+            positionen=positionen,
+            versandkosten=versandkosten,
+            total=total,
+            rabattbetrag=rabattbetrag,
+            rabattcode=rabattcode,
+        )
+
+        params: dict = {
+            "sender": {"email": "bestellung@olivalle.ch", "name": "Olivalle"},
+            "to": [{"email": empfaenger}],
+            "reply_to": {"email": "olivalle.olten@outlook.com"},
+            "subject": betreff,
+            "html_content": html,
+        }
+
+        if anhang:
+            params["attachment"] = [
+                {
+                    "content": base64.b64encode(anhang).decode("utf-8"),
+                    "name": f"rechnung-{bestell_id}.pdf",
+                }
+            ]
+
         result = brevo_client.transactional_emails.send_transac_email(**params)
     except Exception:
-        # Ein Brevo-Ausfall darf den Bestellablauf nicht kippen: die Bestellung
-        # ist zu diesem Zeitpunkt bereits persistiert. Fehler protokollieren
-        # (email_fehler), damit der Betreiber die Mail manuell nachsenden kann.
+        # Weder Brevo-Ausfall noch Template-Fehler dürfen den Bestellablauf
+        # kippen: die Bestellung ist zu diesem Zeitpunkt bereits persistiert.
+        # Fehler protokollieren (email_fehler), damit der Betreiber die Mail
+        # manuell nachsenden kann.
         logger.exception("Bestellbestätigung konnte nicht gesendet werden: %s", betreff)
         _log_email(
             conn,
@@ -143,13 +144,12 @@ def sende_status_email(
     template_datei, betreff_vorlage = config
     betreff = betreff_vorlage.format(bestell_id=bestellung_id)
 
-    template = env.get_template(template_datei)
-    html = template.render(
-        kunde_vorname=bestellung["vorname"],
-        bestell_id=bestellung_id,
-    )
-
     try:
+        template = env.get_template(template_datei)
+        html = template.render(
+            kunde_vorname=bestellung["vorname"],
+            bestell_id=bestellung_id,
+        )
         brevo_client.transactional_emails.send_transac_email(
             sender={"email": "bestellung@olivalle.ch", "name": "Olivalle"},
             to=[{"email": bestellung["email"]}],
@@ -185,22 +185,21 @@ def sende_stakeholder_benachrichtigung(
     rabattcode: str = "",
 ) -> object:
     """Benachrichtigt den Stakeholder über eine neue Bestellung."""
-    template = env.get_template("bestellung_stakeholder.html")
-    html = template.render(
-        bestell_id=bestell_id,
-        kunde=kunde,
-        positionen=positionen,
-        versandkosten=versandkosten,
-        total=total,
-        zahlungsart=zahlungsart,
-        zahlungsart_label=ZAHLUNGSART_LABELS_EMAIL.get(zahlungsart, zahlungsart),
-        versandart_label=VERSANDART_LABELS.get(versandart, versandart),
-        rabattbetrag=rabattbetrag,
-        rabattcode=rabattcode,
-    )
-
     betreff = f"Neue Bestellung #{bestell_id}"
     try:
+        template = env.get_template("bestellung_stakeholder.html")
+        html = template.render(
+            bestell_id=bestell_id,
+            kunde=kunde,
+            positionen=positionen,
+            versandkosten=versandkosten,
+            total=total,
+            zahlungsart=zahlungsart,
+            zahlungsart_label=ZAHLUNGSART_LABELS_EMAIL.get(zahlungsart, zahlungsart),
+            versandart_label=VERSANDART_LABELS.get(versandart, versandart),
+            rabattbetrag=rabattbetrag,
+            rabattcode=rabattcode,
+        )
         result = brevo_client.transactional_emails.send_transac_email(
             sender={"email": "bestellung@olivalle.ch", "name": "Olivalle"},
             to=[{"email": "olivalle.olten@outlook.com"}],

--- a/docs/bestellprozess.md
+++ b/docs/bestellprozess.md
@@ -61,6 +61,7 @@ sequenceDiagram
 - **QR-Rechnungs-Pfad** — für Rechnungskäufer erzeugt der Shop ein Schweizer QR-Rechnungs-PDF und versendet es als E-Mail-Anhang.
 - **Bar bei Abholung** — nur zulässig in Kombination mit Versandart „Abholung" (Region Olten): der Shop verschickt sofort eine Bestätigung über ein eigenes Template (`bestellbestaetigung_abholung_bar.html`), ohne Stripe und ohne QR-Rechnung.
 - **Betreiber-Benachrichtigung** — bei *jeder* erfolgreichen Bestellung (alle drei Zahlwege) geht zusätzlich zur Kundenmail eine zweite E-Mail an den Betreiber. Pro Bestellung entstehen also **zwei** Brevo-Mails — relevant fürs Free-Tier-Limit (siehe arc42 §7).
+- **E-Mail-Fehlertoleranz** — ein Brevo-Ausfall (oder Template-Fehler) kippt die Bestellung nicht: sie bleibt erfolgreich gespeichert, der fehlgeschlagene Versand wird als `email_fehler` im Audit-Log (`admin_log`) protokolliert. Bei Verdacht auf fehlende Mails dort nachschauen und manuell nachsenden (Issue #162).
 
 ---
 

--- a/tests/test_email_service.py
+++ b/tests/test_email_service.py
@@ -213,3 +213,68 @@ class TestMailFehlertoleranz:
             "SELECT * FROM admin_log WHERE aktion = 'email_fehler'"
         ).fetchone()
         assert fehler is not None
+        ausgang = db.execute(
+            "SELECT * FROM admin_log WHERE aktion = 'email_ausgang'"
+        ).fetchone()
+        assert ausgang is None
+
+    @patch("app.services.email_service.env")
+    def test_bestellbestaetigung_bei_renderfehler_kein_raise(self, mock_env, db):
+        """Auch ein Template-/Render-Fehler darf den Bestellablauf nicht kippen."""
+        self._order(db)
+        mock_env.get_template.side_effect = RuntimeError("template kaputt")
+        result = sende_bestellbestaetigung(
+            empfaenger="max@test.ch",
+            bestell_id=1,
+            kunde={"vorname": "Max", "nachname": "Muster"},
+            positionen=[{"name": "Öl 250ml", "menge": 1, "einzelpreis_chf": 8.0}],
+            versandkosten=0.0,
+            total=8.0,
+            conn=db,
+        )
+        assert result is None
+        fehler = db.execute(
+            "SELECT * FROM admin_log WHERE aktion = 'email_fehler'"
+        ).fetchone()
+        assert fehler is not None
+
+    @patch("app.services.email_service.env")
+    def test_stakeholder_bei_renderfehler_kein_raise(self, mock_env, db):
+        from app.services.email_service import sende_stakeholder_benachrichtigung
+
+        self._order(db)
+        mock_env.get_template.side_effect = RuntimeError("template kaputt")
+        result = sende_stakeholder_benachrichtigung(
+            bestell_id=1,
+            kunde={"vorname": "Max", "nachname": "Muster", "email": "max@test.ch"},
+            positionen=[{"name": "Öl 250ml", "menge": 1, "einzelpreis_chf": 8.0}],
+            versandkosten=0.0,
+            total=8.0,
+            zahlungsart="rechnung",
+            versandart="versand",
+            conn=db,
+        )
+        assert result is None
+        fehler = db.execute(
+            "SELECT * FROM admin_log WHERE aktion = 'email_fehler'"
+        ).fetchone()
+        assert fehler is not None
+
+    @patch("app.services.email_service.env")
+    def test_status_email_bei_renderfehler_kein_raise(self, mock_env, db):
+        db.execute(
+            "INSERT INTO kunden (vorname, nachname, email, strasse, plz, ort) "
+            "VALUES ('Max', 'Muster', 'max@test.ch', 'Str 1', '4600', 'Olten')"
+        )
+        db.execute(
+            "INSERT INTO bestellungen "
+            "(kunde_id, status, zahlungsart, versandart, total_chf) "
+            "VALUES (1, 'neu', 'rechnung', 'versand', 50.00)"
+        )
+        db.commit()
+        mock_env.get_template.side_effect = RuntimeError("template kaputt")
+        sende_status_email(bestellung_id=1, neuer_status="bezahlt", conn=db)
+        fehler = db.execute(
+            "SELECT * FROM admin_log WHERE aktion = 'email_fehler'"
+        ).fetchone()
+        assert fehler is not None

--- a/tests/test_email_service.py
+++ b/tests/test_email_service.py
@@ -148,3 +148,68 @@ class TestSendeStatusEmail:
                 mock_client.transactional_emails.send_transac_email.call_args.kwargs
             )
             assert "Zahlungseingang" in call_kwargs["subject"]
+
+
+class TestMailFehlertoleranz:
+    """Brevo-Ausfall darf den Bestellablauf nie kippen (#162)."""
+
+    def _order(self, db):
+        db.execute(
+            "INSERT INTO kunden (vorname, nachname, email, strasse, plz, ort) "
+            "VALUES ('Max', 'Muster', 'max@test.ch', 'Str 1', '4600', 'Olten')"
+        )
+        db.execute(
+            "INSERT INTO bestellungen (kunde_id, zahlungsart, versandart, total_chf) "
+            "VALUES (1, 'rechnung', 'versand', 50.00)"
+        )
+        db.commit()
+
+    @patch("app.services.email_service.brevo_client")
+    def test_bestellbestaetigung_bei_brevo_fehler_kein_raise(self, mock_client, db):
+        self._order(db)
+        mock_client.transactional_emails.send_transac_email.side_effect = RuntimeError(
+            "brevo down"
+        )
+        result = sende_bestellbestaetigung(
+            empfaenger="max@test.ch",
+            bestell_id=1,
+            kunde={"vorname": "Max", "nachname": "Muster"},
+            positionen=[{"name": "Öl 250ml", "menge": 1, "einzelpreis_chf": 8.0}],
+            versandkosten=0.0,
+            total=8.0,
+            conn=db,
+        )
+        assert result is None
+        fehler = db.execute(
+            "SELECT * FROM admin_log WHERE aktion = 'email_fehler'"
+        ).fetchone()
+        assert fehler is not None
+        assert "max@test.ch" in fehler["details"]
+        ausgang = db.execute(
+            "SELECT * FROM admin_log WHERE aktion = 'email_ausgang'"
+        ).fetchone()
+        assert ausgang is None
+
+    @patch("app.services.email_service.brevo_client")
+    def test_stakeholder_bei_brevo_fehler_kein_raise(self, mock_client, db):
+        from app.services.email_service import sende_stakeholder_benachrichtigung
+
+        self._order(db)
+        mock_client.transactional_emails.send_transac_email.side_effect = RuntimeError(
+            "brevo down"
+        )
+        result = sende_stakeholder_benachrichtigung(
+            bestell_id=1,
+            kunde={"vorname": "Max", "nachname": "Muster", "email": "max@test.ch"},
+            positionen=[{"name": "Öl 250ml", "menge": 1, "einzelpreis_chf": 8.0}],
+            versandkosten=0.0,
+            total=8.0,
+            zahlungsart="rechnung",
+            versandart="versand",
+            conn=db,
+        )
+        assert result is None
+        fehler = db.execute(
+            "SELECT * FROM admin_log WHERE aktion = 'email_fehler'"
+        ).fetchone()
+        assert fehler is not None


### PR DESCRIPTION
Closes #162

## Was

`sende_bestellbestaetigung` und `sende_stakeholder_benachrichtigung` fangen Fehler jetzt selbst ab (Muster von `sende_status_email` übernommen): Fehler wird als `email_fehler` ins Audit-Log (`admin_log`) geschrieben, die Funktion gibt `None` zurück statt zu raisen. `_log_email`-Helper dedupliziert die Log-Blöcke.

Abweichung vom Issue-Vorschlag: try/except liegt in den **Service-Funktionen** statt in den Routern — deckt nachweislich beide Problempfade ab (Stripe-Webhook `webhooks.py` und Rechnung/Abholung `bestellungen.py`) und schützt automatisch künftige Aufrufer.

## Warum

Bisher: Brevo-Exception nach dem atomaren Status-Flip → Webhook 500 → Stripe-Retry trifft `rowcount != 1` → returnt ok **ohne Mail** → Bestellbestätigung dauerhaft und unbemerkt verloren. Beim Rechnungs-/Abholungspfad: HTTP 500 beim Kunden trotz gespeicherter Bestellung → Doppelbestellungs-Risiko.

## Review

Code-Review durchgeführt; Important-Finding gefixt: Das Template-Rendering lag ausserhalb des try — ein Render-Fehler hätte den Flow weiterhin gekippt. Jetzt liegt `get_template`/`render` in allen drei Sendefunktionen im try (inkl. `sende_status_email`), mit 3 neuen Tests.

Bewusst offen gelassen (Review-Minors, pre-existing bzw. ausserhalb Scope): Log-Schreibpfad im except selbst ungeschützt; Restlücke zwischen Commit und Mailversand im Webhook (DB-lokale Queries).

## Tests

- 15 Tests in `tests/test_email_service.py` (5 neue Fehlertoleranz-Tests: Brevo-Fehler + Render-Fehler je Funktion)
- Gesamte Suite: 270 passed, `make lint-all` grün
- `docs/bestellprozess.md`: Hinweis ergänzt, dass verlorene Mails als `email_fehler` im `admin_log` auffindbar sind

🤖 Generated with [Claude Code](https://claude.com/claude-code)