### PR TITLE
fix: Spalten-Whitelist in rabattcode_aktualisieren gegen SQL-Injection (#163)

### DIFF
--- a/app/repositories/rabattcode_repo.py
+++ b/app/repositories/rabattcode_repo.py
@@ -58,10 +58,34 @@ def alle_rabattcodes(conn: sqlite3.Connection) -> list[dict]:
     return [dict(r) for r in rows]
 
 
+# Spalten, die ueber rabattcode_aktualisieren() geschrieben werden duerfen.
+# Verhindert SQL-Injection ueber Feldnamen (dynamische SET-Klausel).
+_AKTUALISIERBARE_FELDER = frozenset(
+    {
+        "code",
+        "rabattart",
+        "rabattwert",
+        "gueltig_von",
+        "gueltig_bis",
+        "mindestbestellwert_chf",
+        "max_einloesungen",
+        "aktiv",
+    }
+)
+
+
 def rabattcode_aktualisieren(conn: sqlite3.Connection, code_id: int, **felder) -> None:
-    """Rabattcode-Felder aktualisieren."""
+    """Rabattcode-Felder aktualisieren.
+
+    Nur Spalten aus _AKTUALISIERBARE_FELDER sind erlaubt; ein unbekannter
+    Feldname loest einen ValueError aus (Schutz vor SQL-Injection ueber
+    dynamisch zusammengesetzte Spaltennamen).
+    """
     if not felder:
         return
+    unbekannt = set(felder) - _AKTUALISIERBARE_FELDER
+    if unbekannt:
+        raise ValueError(f"Unerlaubte Rabattcode-Felder: {sorted(unbekannt)}")
     set_clause = ", ".join(f"{k} = ?" for k in felder)
     values = list(felder.values()) + [code_id]
     conn.execute(

--- a/app/repositories/rabattcode_repo.py
+++ b/app/repositories/rabattcode_repo.py
@@ -88,6 +88,7 @@ def rabattcode_aktualisieren(conn: sqlite3.Connection, code_id: int, **felder) -
         raise ValueError(f"Unerlaubte Rabattcode-Felder: {sorted(unbekannt)}")
     set_clause = ", ".join(f"{k} = ?" for k in felder)
     values = list(felder.values()) + [code_id]
+    # S608 ok: Spaltennamen oben whitelisted, Werte parametrisiert via ?
     conn.execute(
         f"UPDATE rabattcodes SET {set_clause} WHERE id = ?",  # noqa: S608
         values,

--- a/docs/security.md
+++ b/docs/security.md
@@ -15,6 +15,7 @@ Faktische Bestandsaufnahme der im Code umgesetzten Maßnahmen (kein Vollaudit):
 - **Admin-Auth:** bcrypt-gehashtes Passwort, kein Klartext im Code (`app/services/auth_service.py`).
 - **Stripe-Webhooks:** Signaturprüfung, kein blindes Vertrauen in Webhook-Daten (`app/routers/webhooks.py`).
 - **Secrets:** ausschließlich via Umgebungsvariablen / `fly secrets`; nichts im Repo (`.env` gitignored).
+- **SQL:** durchgehend parametrisierte Queries; dynamische Spaltennamen nur gegen explizite Whitelist (`rabattcode_repo.py`, Issue #163).
 - **Fail-Fast-Konfigcheck:** Der Container bricht beim Start ab, wenn Pflicht-Secrets fehlen oder `SECRET_KEY` auf einem Platzhalter steht (`python -m app.config` in `entrypoint.sh`, Issue #161).
 - **Transport:** HTTPS erzwungen durch fly.io.
 

--- a/tests/test_rabattcode_service.py
+++ b/tests/test_rabattcode_service.py
@@ -1,6 +1,9 @@
+import pytest
+
 from app.repositories.rabattcode_repo import (
     einloesung_speichern,
     ist_bereits_eingeloest,
+    rabattcode_aktualisieren,
     rabattcode_anlegen,
     rabattcode_laden,
     rabattcode_laden_by_code,
@@ -240,3 +243,32 @@ def test_pruefe_rabattcode_mindestbestellwert_erreicht(db):
     _erstelle_testcode(db, mindestbestellwert_chf=25.0)
     result = pruefe_rabattcode(db, "TEST10", "kunde@test.ch", 26.00)
     assert result["gueltig"] is True
+
+
+# --- rabattcode_aktualisieren: Spalten-Whitelist (#163) ---
+
+
+def test_aktualisieren_erlaubtes_feld(db):
+    code_id = _erstelle_testcode(db)
+    rabattcode_aktualisieren(db, code_id, aktiv=0, rabattwert=15.0)
+    rc = rabattcode_laden(db, code_id)
+    assert rc["aktiv"] == 0
+    assert rc["rabattwert"] == 15.0
+
+
+def test_aktualisieren_unbekanntes_feld_wirft(db):
+    code_id = _erstelle_testcode(db)
+    with pytest.raises(ValueError, match="Unerlaubte Rabattcode-Felder"):
+        rabattcode_aktualisieren(db, code_id, id=999)
+
+
+def test_aktualisieren_injection_feldname_wirft(db):
+    code_id = _erstelle_testcode(db)
+    with pytest.raises(ValueError, match="Unerlaubte Rabattcode-Felder"):
+        rabattcode_aktualisieren(db, code_id, **{"aktiv = 1 WHERE 1=1; --": "x"})
+
+
+def test_aktualisieren_ohne_felder_ist_noop(db):
+    code_id = _erstelle_testcode(db)
+    rabattcode_aktualisieren(db, code_id)
+    assert rabattcode_laden(db, code_id) is not None


### PR DESCRIPTION
Closes #163

## Was

`rabattcode_aktualisieren(conn, code_id, **felder)` prüft Feldnamen jetzt gegen die explizite Whitelist `_AKTUALISIERBARE_FELDER` (die 8 legitimen Update-Spalten); unbekanntes Feld → `ValueError`. Werte laufen unverändert parametrisiert. Dazu: noqa-Begründung als Kommentar und neue SQL-Regel in `docs/security.md`.

## Warum

Die dynamische SET-Klausel interpolierte Feldnamen direkt ins SQL (f-String, `# noqa: S608`). Der heutige Aufrufer übergibt feste Kwargs — nicht ausnutzbar —, aber der nächste Aufrufer mit `**form_dict` hätte SQL-Injection über Spaltennamen.

## Review

Code-Review durchgeführt: **Ready to merge (Yes)**, keine Critical/Important-Findings. Whitelist gegen Schema (`migrations/003_rabattcodes.sql`) und den realen Aufrufer verifiziert — bewusst enger als das Schema (`id`, `aktuelle_einloesungen`, `erstellt_am` ausgeschlossen). Zwei Minor-Punkte (noqa-Kommentar, security.md-Bullet) in diesem PR umgesetzt.

Nebenbefund aus dem Review (pre-existing, nicht dieser PR): Die Rabattcode-Admin-POST-Routen validieren ihr CSRF-Token nicht — wird als separates Security-Issue erfasst.

## Tests

- 4 neue Tests (Injection-Feldname → ValueError, echte-aber-verbotene Spalte `id`, legitimes Update mit Reload-Verifikation, No-op bei leeren Feldern)
- Gesamte Suite: 269 passed, `make lint-all` grün

🤖 Generated with [Claude Code](https://claude.com/claude-code)